### PR TITLE
Fix some more warnings

### DIFF
--- a/.vs/libcdio.vcxproj
+++ b/.vs/libcdio.vcxproj
@@ -90,7 +90,7 @@
     <ClCompile>
       <PreprocessorDefinitions>WIN32;HAVE_CONFIG_H;_CONSOLE;_MBCS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <DisableSpecificWarnings>4018;4133;4333;4996</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4018;4133;4333;4996;28159</DisableSpecificWarnings>
     </ClCompile>
     <Lib />
     <PreBuildEvent>
@@ -102,7 +102,7 @@
     <ClCompile>
       <PreprocessorDefinitions>WIN32;HAVE_CONFIG_H;_CONSOLE;_MBCS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <DisableSpecificWarnings>4018;4133;4333;4996</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4018;4133;4333;4996;28159</DisableSpecificWarnings>
     </ClCompile>
     <PreBuildEvent>
       <Command>powershell.exe -File "$(ProjectDir)set_version.ps1"</Command>
@@ -149,7 +149,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <DisableSpecificWarnings>4018;4133;4333;4996</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4018;4133;4333;4996;28159</DisableSpecificWarnings>
       <PreprocessorDefinitions>WIN32;HAVE_CONFIG_H;_CONSOLE;_MBCS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
@@ -160,7 +160,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <DisableSpecificWarnings>4018;4133;4333;4996</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4018;4133;4333;4996;28159</DisableSpecificWarnings>
       <PreprocessorDefinitions>WIN32;HAVE_CONFIG_H;_CONSOLE;_MBCS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>

--- a/lib/driver/MSWindows/aspi32.c
+++ b/lib/driver/MSWindows/aspi32.c
@@ -136,7 +136,7 @@ mciSendCommand_aspi(int id, UINT msg, DWORD flags, void *arg)
   if ( mci_error ) {
     char error[256];
 
-    mciGetErrorString(mci_error, error, 256);
+    mciGetErrorStringA(mci_error, error, 256);
     cdio_warn("mciSendCommand() error: %s", error);
   }
   return(mci_error == 0);
@@ -152,7 +152,7 @@ have_aspi( HMODULE *hASPI,
            long (**lpSendCommand)( void* ) )
 {
   /* check if aspi is available */
-  *hASPI = LoadLibrary( "wnaspi32.dll" );
+  *hASPI = LoadLibraryA( "wnaspi32.dll" );
 
   if( *hASPI == NULL ) {
     cdio_warn("Unable to load ASPI DLL");

--- a/lib/driver/MSWindows/win32.c
+++ b/lib/driver/MSWindows/win32.c
@@ -73,6 +73,7 @@
 
 #if defined (_MSC_VER) || defined (_XBOX)
 #undef IN
+extern const char* is_cdrom_aspi(const char drive_letter);
 #else
 #include "aspi32.h"
 #endif
@@ -209,7 +210,7 @@ _cdio_mciSendCommand(int id, UINT msg, DWORD flags, void *arg)
   if ( mci_error ) {
     char error[256];
 
-    mciGetErrorString(mci_error, error, 256);
+    mciGetErrorStringA(mci_error, error, 256);
     cdio_warn("mciSendCommand() error: %s", error);
   }
   return(mci_error == 0);

--- a/lib/driver/MSWindows/win32.c
+++ b/lib/driver/MSWindows/win32.c
@@ -1034,6 +1034,9 @@ cdio_open_am_win32 (const char *psz_orig_source, const char *psz_access_mode)
   _funcs.set_speed              = set_drive_speed_mmc;
 
   _data                 = calloc(1, sizeof (_img_private_t));
+  if (NULL == _data) {
+    goto error_exit;
+  }
   _data->access_mode    = str_to_access_mode_win32(psz_access_mode);
   _data->gen.init       = false;
   _data->gen.fd         = -1;

--- a/lib/driver/MSWindows/win32_ioctl.c
+++ b/lib/driver/MSWindows/win32_ioctl.c
@@ -584,6 +584,7 @@ run_mmc_cmd_win32ioctl( void *p_user_data,
     sizeof(SCSI_PASS_THROUGH_WITH_BUFFERS) + u_buf;
 
   p_sptwb = malloc(u_swb_len);
+  if (!p_sptwb) return DRIVER_OP_ERROR;
 
   p_env->gen.scsi_mmc_sense_valid = 0;
   memset(p_sptwb, 0, u_swb_len);

--- a/lib/driver/MSWindows/win32_ioctl.c
+++ b/lib/driver/MSWindows/win32_ioctl.c
@@ -77,7 +77,7 @@
 #define windows_error(loglevel,i_err) {                                 \
   char error_msg[80];                                                   \
   long int count;                                                       \
-  count = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM,                      \
+  count = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM,                     \
                         NULL, i_err, MAKELANGID(LANG_NEUTRAL,            \
                                                 SUBLANG_DEFAULT),        \
                         error_msg, sizeof(error_msg), NULL);             \

--- a/lib/driver/_cdio_generic.c
+++ b/lib/driver/_cdio_generic.c
@@ -253,6 +253,8 @@ cdio_add_device_list(char **device_list[], const char *drive,
       /* Drive not in list. Add it. */
       (*num_drives)++;
       *device_list = realloc(*device_list, (*num_drives) * sizeof(char *));
+      if (NULL == *device_list)
+        return;
       cdio_debug("Adding drive %s to list of devices", drive);
       (*device_list)[*num_drives-1] = strdup(drive);
       }
@@ -264,6 +266,8 @@ cdio_add_device_list(char **device_list[], const char *drive,
     } else {
       *device_list = malloc((*num_drives) * sizeof(char *));
     }
+    if (NULL == *device_list)
+      return;
     cdio_debug("Adding NULL to end of drive list of size %d", (*num_drives)-1);
     (*device_list)[*num_drives-1] = NULL;
   }

--- a/lib/driver/cdtext.c
+++ b/lib/driver/cdtext.c
@@ -202,7 +202,7 @@ const char *cdtext_language[MAX_CDTEXT_LANGUAGE_CODE + 1] =
 const char *
 cdtext_field2str(cdtext_field_t i)
 {
-  if (i >= MAX_CDTEXT_FIELDS)
+  if (i < 0 || i >= MAX_CDTEXT_FIELDS)
     return "INVALID";
   else
     return cdtext_field[i];
@@ -214,7 +214,7 @@ cdtext_field2str(cdtext_field_t i)
 const char *
 cdtext_genre2str(cdtext_genre_t i)
 {
-  if (i >= MAX_CDTEXT_GENRE_CODE)
+  if (i < 0 || i >= MAX_CDTEXT_GENRE_CODE)
     return "INVALID";
   else
     return cdtext_genre[i];
@@ -226,7 +226,7 @@ cdtext_genre2str(cdtext_genre_t i)
 const char *
 cdtext_lang2str(cdtext_lang_t i)
 {
-  if (i <= CDTEXT_LANGUAGE_WALLON)
+  if (i >= 0 && i <= CDTEXT_LANGUAGE_WALLON)
     return cdtext_language[i];
   else if (i >= CDTEXT_LANGUAGE_ZULU && i <= CDTEXT_LANGUAGE_AMHARIC)
     return cdtext_language[i];

--- a/lib/driver/cdtext.c
+++ b/lib/driver/cdtext.c
@@ -491,6 +491,8 @@ cdtext_t
   cdtext_t *p_cdtext;
 
   p_cdtext = (cdtext_t *) malloc(sizeof(struct cdtext_s));
+  if (p_cdtext == NULL)
+    return NULL;
 
   for (i=0; i<CDTEXT_NUM_BLOCKS_MAX; i++) {
     for (j=0; j<CDTEXT_NUM_TRACKS_MAX; j++) {

--- a/lib/driver/device.c
+++ b/lib/driver/device.c
@@ -895,7 +895,7 @@ cdio_have_atapi(CdIo_t *p_cdio)
 bool
 cdio_have_driver(driver_id_t driver_id)
 {
-  if (driver_id >= sizeof(CdIo_all_drivers)/sizeof(CdIo_all_drivers[0]))
+  if (driver_id < 0 || driver_id >= sizeof(CdIo_all_drivers)/sizeof(CdIo_all_drivers[0]))
     return false;
   return (*CdIo_all_drivers[driver_id].have_driver)();
 }
@@ -914,7 +914,9 @@ cdio_is_device(const char *psz_source, driver_id_t driver_id)
       }
     }
   }
-  if (CdIo_all_drivers[driver_id].is_device == NULL) return false;
+  if (driver_id < DRIVER_UNKNOWN || driver_id >= DRIVER_DEVICE ||
+      CdIo_all_drivers[driver_id].is_device == NULL)
+      return false;
   return (*CdIo_all_drivers[driver_id].is_device)(psz_source);
 }
 

--- a/lib/driver/image/bincue.c
+++ b/lib/driver/image/bincue.c
@@ -854,6 +854,8 @@ parse_cuefile (_img_private_t *cd, const char *psz_cue_name)
         if (cd) {
           if (NULL == cd->gen.cdtext) {
             cd->gen.cdtext = cdtext_init ();
+            if (NULL == cd->gen.cdtext)
+              goto err_exit;
             cd->gen.cdtext->block[cd->gen.cdtext->block_i].language_code = CDTEXT_LANGUAGE_ENGLISH;
           }
           cdtext_set (cd->gen.cdtext, cdtext_key, (uint8_t*) strtok(NULL, "\"\t\n\r"),
@@ -1336,6 +1338,7 @@ cdio_open_cue (const char *psz_cue_name)
   if (NULL == psz_cue_name) return NULL;
 
   p_data                 = calloc(1, sizeof (_img_private_t));
+  if (NULL == p_data) return NULL;
   p_data->gen.init       = false;
   p_data->psz_cue_name   = NULL;
 

--- a/lib/driver/image/cdrdao.c
+++ b/lib/driver/image/cdrdao.c
@@ -1343,6 +1343,8 @@ cdio_open_cdrdao (const char *psz_cue_name)
   if (NULL == psz_cue_name) return NULL;
 
   p_data                  = calloc(1, sizeof (_img_private_t));
+  if (NULL == p_data) return NULL;
+
   p_data->gen.init        = false;
   p_data->psz_cue_name    = NULL;
   p_data->gen.data_source = NULL;

--- a/lib/driver/image/nrg.c
+++ b/lib/driver/image/nrg.c
@@ -88,6 +88,8 @@ _register_mapping (_img_private_t *env, lsn_t start_lsn, uint32_t sec_count,
   track_info_t  *this_track=&(env->tocent[env->gen.i_tracks]);
   _mapping_t *_map = calloc(1, sizeof (_mapping_t));
 
+  if (_map == NULL)
+    return;
   _map->start_lsn  = start_lsn;
   _map->sec_count  = sec_count;
   _map->img_offset = img_offset;
@@ -384,6 +386,8 @@ parse_nrg (_img_private_t *p_env, const char *psz_nrg_name,
 
 	  /* We include an extra 0 byte so these can be used as C strings.*/
 	  p_env->psz_mcn = calloc(1, CDIO_MCN_SIZE+1);
+	  if (p_env->psz_mcn == NULL)
+	    return false;
 	  memcpy(p_env->psz_mcn, &(_dao_common->psz_mcn), CDIO_MCN_SIZE);
 	  p_env->psz_mcn[CDIO_MCN_SIZE] = '\0';
 
@@ -1270,7 +1274,7 @@ cdio_is_nrg(const char *psz_nrg)
   _img_private_t *p_env  = calloc(1, sizeof (_img_private_t));
   bool is_nrg = false;
 
-  if (psz_nrg == NULL) {
+  if (p_env == NULL || psz_nrg == NULL) {
     is_nrg = false;
     goto exit;
   }
@@ -1361,6 +1365,9 @@ cdio_open_nrg (const char *psz_source)
   _funcs.set_arg               = _set_arg_image;
 
   _data                   = calloc(1, sizeof (_img_private_t));
+  if (_data == NULL) {
+    return NULL;
+  }
   _data->gen.init         = false;
 
   _data->gen.i_tracks     = 0;


### PR DESCRIPTION
Turns out I had a few more warnings fixes in store, mostly to address the ones reported by the Visual Studio static analyser (some of which, such as the unwanted use of widestring calls, were actual issues), so here's a new patchset to fix those.

The first patch is mostly about fixing the widestring API call issue, as well a silencing a couple specific MSVC warnings,
The second is about the Visual Studio static analyser complaining that we don't consistently check for NULL buffer after allocs.
The last one is about the Visual Studio static analyser complaining that we should check for the validity of an enum range, including underflow, before using it to access an array.