### PR TITLE
Copy clang-format definition and CI from libcdio-paranoia

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Run code linter
+
+on: [push, pull_request]
+
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: lint-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.fedoraproject.org/fedora:latest
+    steps:
+    - name: Install tools
+      run: sudo dnf -y install git make clang-tools-extra which git-clang-format
+
+    - uses: actions/checkout@v4
+
+    - name: Set git safe directory
+      # https://github.com/actions/checkout/issues/760
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+    - name: Run make indent
+      run: |
+        if [ -z "${{github.base_ref}}" ]; then
+          git fetch --deepen=1
+          git clang-format --diff --style file --extensions c,h "HEAD~1"
+        else
+          git fetch origin ${{github.base_ref}}
+          git clang-format --diff --style file --extensions c,h origin/${{github.base_ref}}
+        fi


### PR DESCRIPTION
As mentioned in https://github.com/libcdio/libcdio-paranoia/pull/53 this is a copy of libcdio-paranoia's .clang-format and corresponding CI runs.

The files in this repository are not conforming to the `.clang-format` definition. The code would change a lot. Not sure if you want to first change the code formatting before adding the CI job. The CI job should only look at files that have changed.