### PR TITLE
Support reading CD-Text with the Win32 IOCTL driver

### DIFF
--- a/lib/driver/MSWindows/win32.c
+++ b/lib/driver/MSWindows/win32.c
@@ -708,6 +708,36 @@ get_arg_win32 (void *p_user_data, const char key[])
   return NULL;
 }
 
+/**
+  Read CD-Text binary data.
+*/
+static uint8_t *
+read_cdtext_win32(void *p_user_data)
+{
+  const _img_private_t *p_env = p_user_data;
+
+  if( p_env->hASPI ) {
+    return read_cdtext_generic(p_user_data);
+  } else {
+    return read_cdtext_win32ioctl(p_user_data);
+  }
+}
+
+/**
+  Read CD-Text and return cdtext_t structure.
+*/
+static cdtext_t *
+get_cdtext_win32 (void *p_user_data)
+{
+  const _img_private_t *p_env = p_user_data;
+
+  if( p_env->hASPI ) {
+    return get_cdtext_generic(p_user_data);
+  } else {
+    return get_cdtext_win32ioctl(p_user_data);
+  }
+}
+
 /*!
   Return the media catalog number MCN.
 
@@ -997,8 +1027,8 @@ cdio_open_am_win32 (const char *psz_orig_source, const char *psz_access_mode)
   _funcs.eject_media            = eject_media_win32;
   _funcs.free                   = free_win32;
   _funcs.get_arg                = get_arg_win32;
-  _funcs.get_cdtext             = get_cdtext_generic;
-  _funcs.get_cdtext_raw         = read_cdtext_generic;
+  _funcs.get_cdtext             = get_cdtext_win32;
+  _funcs.get_cdtext_raw         = read_cdtext_win32;
   _funcs.get_default_device     = cdio_get_default_device_win32;
   _funcs.get_devices            = cdio_get_devices_win32;
   _funcs.get_disc_last_lsn      = get_disc_last_lsn_win32;

--- a/lib/driver/MSWindows/win32.h
+++ b/lib/driver/MSWindows/win32.h
@@ -194,6 +194,16 @@ get_last_session_win32ioctl (void *p_user_data,
                              /*out*/ lsn_t *i_last_session);
 
 /*!
+  Read CD-Text binary data.
+ */
+uint8_t *read_cdtext_win32ioctl (void *p_user_data);
+
+/*!
+  Read CD-Text and return cdtext_t structure.
+ */
+cdtext_t *get_cdtext_win32ioctl (void *p_user_data);
+
+/*!
   Return the media catalog number MCN.
 
   Note: string is malloc'd so caller should free() then returned

--- a/lib/driver/utf8.c
+++ b/lib/driver/utf8.c
@@ -288,7 +288,7 @@ bool cdio_charset_from_utf8(cdio_utf8_t * src, char ** dst,
   wchar_t* le_dst;
   size_t i, len;
 
-  if (src == NULL || dst == NULL || dst_len == NULL || dst_charset == NULL || strcmp(dst_charset, "UTF-8") != 0)
+  if (src == NULL || dst == NULL || dst_len == NULL || dst_charset == NULL || strcmp(dst_charset, "UCS-2BE") != 0)
     return false;
 
   /* Eliminate empty strings */

--- a/lib/driver/utf8.c
+++ b/lib/driver/utf8.c
@@ -314,37 +314,79 @@ bool cdio_charset_from_utf8(cdio_utf8_t * src, char ** dst,
 bool cdio_charset_to_utf8(const char *src, size_t src_len, cdio_utf8_t **dst,
                           const char *src_charset)
   {
-  wchar_t* le_src;
-  int i;
+  int codepage = 0;
+  wchar_t* wstr = NULL;
+  int i, size = 0;
 
-  if (src == NULL || dst == NULL || src_charset == NULL || strcmp(src_charset, "UCS-2BE") != 0)
+  if (src == NULL || dst == NULL || src_charset == NULL)
     return false;
 
-  /* Compute UCS-2 src length */
-  if (src_len == (size_t)-1) {
-    for (src_len = 0; ((uint16_t*)src)[src_len] !=0; src_len++);
-  } else {
-    src_len >>=1;
+  /* Convert big endian to little endian */
+  if (strcmp(src_charset, "UCS-2BE") == 0) {
+    /* Compute UCS-2 src length */
+    if (src_len == (size_t)-1) {
+      for (src_len = 0; ((uint16_t*)src)[src_len] !=0; src_len++);
+    } else {
+      src_len >>=1;
+    }
+
+    /* Eliminate empty strings */
+    if ((src_len < 1) || ((src[0] == 0) && (src[1] == 0))) {
+      *dst = NULL;
+      return false;
+    }
+
+    /* Perform byte reversal */
+    wstr = (wchar_t*)calloc(src_len+1, sizeof(wchar_t));
+    cdio_assert(wstr != NULL);
+    for (i=0; i<src_len; i++) {
+      ((char*)wstr)[2*i] = src[2*i+1];
+      ((char*)wstr)[2*i+1] = src[2*i];
+    }
+    wstr[src_len] = 0;
   }
 
-  /* Eliminate empty strings */
-  if ((src_len < 1) || ((src[0] == 0) && (src[1] == 0))) {
-    *dst = NULL;
-    return false;
+  /* Convert multi-byte to wide string */
+  if (strcmp(src_charset, "ASCII") == 0 || strcmp(src_charset, "ISO-8859-1") == 0) {
+    codepage = 28591;
+  } else if (strcmp(src_charset, "SHIFT_JIS") == 0) {
+    codepage = 932;
   }
 
-  /* Perform byte reversal */
-  le_src = (wchar_t*)malloc(2*src_len+2);
-  cdio_assert(le_src != NULL);
-  for (i=0; i<src_len; i++) {
-    ((char*)le_src)[2*i] = src[2*i+1];
-    ((char*)le_src)[2*i+1] = src[2*i];
-  }
-  le_src[src_len] = 0;
-  *dst = cdio_wchar_to_utf8(le_src);
-  free(le_src);
+  if (codepage != 0) {
+    /* Compute src length */
+    if (src_len == (size_t)-1) {
+      for (src_len = 0; src[src_len] != 0; src_len++);
+    }
 
-  return (*dst != NULL);
+    /* Eliminate empty strings */
+    if ((src_len < 1) || (src[0] == 0)) {
+      *dst = NULL;
+      return false;
+    }
+
+    /* Find out the size we need to allocate for our converted string */
+    size = MultiByteToWideChar(codepage, 0, src, -1, NULL, 0);
+    if (size <= 1) /* An empty string would be size 1 */
+      return false;
+
+    if ((wstr = (wchar_t*)calloc(size, sizeof(wchar_t))) == NULL)
+      return false;
+
+    if (MultiByteToWideChar(CP_UTF8, 0, src, -1, wstr, size) != size) {
+      free(wstr);
+      return false;
+    }
+  }
+
+  /* Convert wide string to UTF-8 */
+  if (wstr != NULL) {
+    *dst = cdio_wchar_to_utf8(wstr);
+    free(wstr);
+    return (*dst != NULL);
+  }
+
+  return false;
 }
 #else
 # error "The iconv library is needed to build drivers, but it is not detected"


### PR DESCRIPTION
I pushed this to a branch on the Savannah repo back in 2023 intending to merge it maybe a week later, but that never happened.

This fixes CD-Text issues on Windows. Would be great to get this into the 2.1.1 release.