### PR TITLE
Get ready for release 2.2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,17 @@ NEWS
 
 Here we have a summary of the major changes by release. See the git commit history or `ChangeLog` for more fine-grained changes.
 
+Version 2.2.0
+-------------
+
+2025-01-09
+
+Revised to note ABI change in ISO-9660 shared library (`.so`) version
+numbers; bump release version from 2.1.1 to 2.2.0 to note both API and
+ABI changes. These are the last two bullet items under Version 2.1.1
+below. Noticed by Jan Alexander Steffens.
+
+
 Version 2.1.1
 -------------
 
@@ -36,6 +47,8 @@ Version 2.1.1
 - Update freedb references to GnuDB. (Robert Kausch)
 - Fix charset check in Windows cdio_charset_from_utf8 implementation. (Robert Kausch)
 - Add support for reading CD-Text on macOS and Windows (Robert Kausch)
+- API change: some `ecma_167.h` fields were changed from integer (prefix `i_`)  to unsigned in (prefix `u_`)
+- ABI change: `u_su_fields` added to the end of `is_rock_statbuf_t`
 
 Version 2.1.0
 -------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@ Version 2.2.0
 
 Revised to note ABI change in ISO-9660 shared library (`.so`) version
 numbers; bump release version from 2.1.1 to 2.2.0 to note both API and
-ABI changes. These are the last two bullet items under Version 2.1.1
+ABI changes. These are the last three bullet items under Version 2.1.1
 below. Noticed by Jan Alexander Steffens.
 
 
@@ -47,8 +47,9 @@ Version 2.1.1
 - Update freedb references to GnuDB. (Robert Kausch)
 - Fix charset check in Windows cdio_charset_from_utf8 implementation. (Robert Kausch)
 - Add support for reading CD-Text on macOS and Windows (Robert Kausch)
-- API change: some `ecma_167.h` fields were changed from integer (prefix `i_`)  to unsigned in (prefix `u_`)
-- ABI change: `u_su_fields` added to the end of `is_rock_statbuf_t`
+- API change: Rename some fields in `ecma_167.h` from integer (prefix `i_`)  to unsigned (prefix `u_`) to actually match their type
+- ABI change: Add `u_su_fields` to the end of `iso_rock_statbuf_t`
+- ABI change: Add `total_size` in the middle of `iso9660_stat_t`
 
 Version 2.1.0
 -------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,11 @@ Version 2.2.0
 Revised to note ABI change in ISO-9660 shared library (`.so`) version
 numbers; bump release version from 2.1.1 to 2.2.0 to note both API and
 ABI changes. These are the last three bullet items under Version 2.1.1
-below. Noticed by Jan Alexander Steffens.
+below.
+
+Remove `LIBCDIO_SOURCE_PATH` from `configure.ac`. See https://github.com/libcdio/libcdio/issues/13.
+
+Changes noticed and offered by Jan Alexander Steffens.
 
 
 Version 2.1.1
@@ -19,10 +23,12 @@ Version 2.1.1
 
 2025-01-07
 
-- More checks of potentially NULL buffers. More check of the result of malloc/calloc.
-- Enforce the use of non widestring (A suffixed) calls when we pass char* parameters. (Pete Batard)
+*Note: there was ABI and API breakage between this release and 2.1.0 which is not reflected in dynamic library `.so` version numbers. Please use release 2.2.0 for these corrections.*
+
+- More checks of potentially NULL buffers. More `malloc()`/`calloc()` result checks.
+- Enforce non-widestring ("A" suffixed) calls when we pass `char*` parameters. (Pete Batard)
 - Use widestring API calls unless otherwise specified.
-- Remove a warning about the declaration of is_cdrom_aspi() and about GetVersion() being deprecated. (Pete Batard)
+- Remove a deprecation warning of the declaration of `is_cdrom_aspi() `and `GetVersion()`. (Pete Batard)
 - Updates for compiling on MSVC. (Pete Batard)
 - Move to github (rocky)
 - Add github CI checks. (Pete Batard)

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ dnl
 dnl You should have received a copy of the GNU General Public License
 dnl along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-define(RELEASE_NUM, 2.1.2.dev0)
+define(RELEASE_NUM, 2.2.0)
 define(CDIO_VERSION_STR, $1)
 
 AC_PREREQ([2.71])
@@ -37,7 +37,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])],
 
 # FIXME: write a m4 macro to convert x.y.zjunk to x*10000 + y*100 + z
 # LIBCDIO_VERSION_NUM=`echo RELEASE_NUM | cut -d . -f 1 | tr -d a-z`
-LIBCDIO_VERSION_NUM=20100
+LIBCDIO_VERSION_NUM=20200
 AC_SUBST(LIBCDIO_VERSION_NUM)
 
 AM_MISSING_PROG(HELP2MAN, help2man, $missing_dir)

--- a/lib/cdio++/Makefile.am
+++ b/lib/cdio++/Makefile.am
@@ -1,6 +1,4 @@
-#   $Id: Makefile.am,v 1.11 2008/10/29 09:53:00 rocky Exp $
-#
-#   Copyright (C) 2005, 2006, 2007, 2008 Rocky Bernstein <rocky@gnu.org>
+#   Copyright (C) 2005, 2006, 2007, 2008, 2025 Rocky Bernstein <rocky@gnu.org>
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -53,7 +51,7 @@ libcdio___la_SOURCES = $(libcdiopp_sources)
 libcdio___la_LDFLAGS = -version-info $(libcdiopp_la_CURRENT):$(libcdiopp_la_REVISION):$(libcdiopp_la_AGE) @LT_NO_UNDEFINED@
 libcdio___la_LIBADD = $(top_builddir)/lib/driver/libcdio.la
 
-libiso9660pp_la_CURRENT = 0
+libiso9660pp_la_CURRENT = 1
 libiso9660pp_la_REVISION = 0
 libiso9660pp_la_AGE = 0
 

--- a/lib/iso9660/Makefile.am
+++ b/lib/iso9660/Makefile.am
@@ -1,4 +1,4 @@
-#   Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2012
+#   Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2012, 2025
 #   Rocky Bernstein <rocky@gnu.org>
 #
 #   This program is free software: you can redistribute it and/or modify
@@ -40,7 +40,7 @@
 #     public release, then set AGE to 0. A changed interface means an
 #     incompatibility with previous versions.
 
-libiso9660_la_CURRENT = 11
+libiso9660_la_CURRENT = 12
 libiso9660_la_REVISION = 0
 libiso9660_la_AGE = 0
 


### PR DESCRIPTION
Revised to note ABI change in ISO-9660 shared library (`.so`) version numbers; bump release version from 2.1.1 to 2.2.0 to note both API and ABI changes. These are the last two bullet items under Version 2.1.1
below.

Fixes #11 