### PR TITLE
Fixed get MCN on Linux

### DIFF
--- a/lib/driver/gnu_linux.c
+++ b/lib/driver/gnu_linux.c
@@ -1714,7 +1714,7 @@ cdio_open_am_linux (const char *psz_orig_source, const char *access_mode)
     .get_hwinfo            = NULL,
     .get_last_session      = get_last_session_linux,
     .get_media_changed     = get_media_changed_linux,
-    .get_mcn               = get_mcn_linux,
+    .get_mcn               = get_mcn_mmc,
     .get_num_tracks        = get_num_tracks_generic,
     .get_track_channels    = get_track_channels_generic,
     .get_track_copy_permit = get_track_copy_permit_generic,

--- a/lib/driver/image/bincue.c
+++ b/lib/driver/image/bincue.c
@@ -818,8 +818,11 @@ parse_cuefile (_img_private_t *cd, const char *psz_cue_name)
                     prev_track->sec_count = 0;
                   } else if ( this_track->start_lba >= prev_track->start_lba
                               + CDIO_PREGAP_SECTORS ) {
-                    prev_track->sec_count = this_track->start_lba -
-                      prev_track->start_lba - CDIO_PREGAP_SECTORS ;
+				if ( this_track->pregap ) {
+	                    prev_track->sec_count = this_track->pregap - prev_track->start_lba ;
+				} else {
+	                    prev_track->sec_count = this_track->start_lba - prev_track->start_lba ;
+				}
                   } else {
                     cdio_log (log_level,
                               "%lu fewer than pregap (%d) sectors in track %d",

--- a/lib/driver/image/cdrdao.c
+++ b/lib/driver/image/cdrdao.c
@@ -875,6 +875,7 @@ parse_tocfile (_img_private_t *cd, const char *psz_cue_name)
 	      cd->tocent[i].start_lba += cdio_mmssff_to_lba (psz_field);
 	      cdio_lba_to_msf(cd->tocent[i].start_lba,
 			      &(cd->tocent[i].start_msf));
+	      cd->tocent[i].sec_count -= cdio_mmssff_to_lba (psz_field);
 	    }
 	  }
 

--- a/lib/driver/image_common.c
+++ b/lib/driver/image_common.c
@@ -138,6 +138,7 @@ _get_drive_cap_image (const void *user_data,
     | CDIO_DRIVE_CAP_READ_MODE2_FORM1
     | CDIO_DRIVE_CAP_READ_MODE2_FORM2
     | CDIO_DRIVE_CAP_READ_MCN
+    | CDIO_DRIVE_CAP_READ_ISRC
     ;
 
   *p_write_cap = 0;


### PR DESCRIPTION
On Linux get MCN returns all zeroes "0000000000000" when ioctl GET_CDROM_MCN is used. Linux kernel does not check MCVAL bit and returns zeroes even if there is no MCN and the response from drive is not valid.