### PR TITLE
Fix MinGW tests

### DIFF
--- a/test/copying-rr-mingw.right
+++ b/test/copying-rr-mingw.right
@@ -6,7 +6,7 @@ ISO-9660 Information
   dr-xr-xr-x   2 0 0 [LSN     24]      2048 Mar 05 2005 16:12:25  copy
   -r-xr-xr-x   1 0 0 [LSN     27]         0 Mar 05 2005 15:26:00  Copy2
   -r--r--r--   1 0 0 [LSN     27]     17992 Mar 05 2005 15:25:51  COPYING
-  -r--r--r--   1 0 0 [LSN     36]         0 Mar 05 2005 15:32:05  fd0
+  br--r--r--   1 0 0 [LSN     36]         0 Mar 05 2005 15:32:05  fd0
   dr-xr-xr-x   2 0 0 [LSN     25]      2048 Mar 05 2005 16:12:25  tmp
   cr--r--r--   1 0 0 [LSN     36]         0 Mar 05 2005 15:31:42  zero
 


### PR DESCRIPTION
MinGW tests break due to MinGW's ls recently having added the block device flag to ls output.
This results in the fd0 special block device making the check_iso.sh fail.
Fix this by adding the 'b' flag to the expected output.