### PR TITLE
Add udf_setpos() function call

### DIFF
--- a/include/cdio/udf.h
+++ b/include/cdio/udf.h
@@ -190,6 +190,15 @@ extern "C" {
     bool udf_get_lba(const udf_file_entry_t *p_udf_fe, 
                      /*out*/ uint32_t *start, /*out*/ uint32_t *end);
 
+    /**
+     * Seek to a specific offset in a UDF file.
+     * The offset *must* be a multiple of UDF_BLOCKSIZE.
+     * Returns true if the position was successfully changed, or false on
+     * any error condition (such as offset out of range or not aligned to
+     * UDF_BLOCKSIZE).
+     */
+    bool udf_setpos(udf_dirent_t* p_udf_dirent, off_t offset);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/lib/udf/udf_file.c
+++ b/lib/udf/udf_file.c
@@ -250,7 +250,7 @@ udf_read_block(const udf_dirent_t *p_udf_dirent, void * buf, size_t count)
       if ( i_max_blocks < count ) {
 	  cdio_warn("read count %u is larger than %u extent size.",
 		  (unsigned int)count, i_max_blocks);
-	  cdio_warn("read count truncated to %u", (unsigned int)count);
+	  cdio_warn("read count truncated to %u", i_max_blocks);
 	  count = i_max_blocks;
       }
       ret = udf_read_sectors(p_udf, buf, i_lba, count);

--- a/lib/udf/udf_fs.c
+++ b/lib/udf/udf_fs.c
@@ -774,3 +774,21 @@ udf_dirent_free(udf_dirent_t *p_udf_dirent)
   }
   return true;
 }
+
+/**
+ * Seek to a specific offset in a UDF file.
+ * The offset *must* be a multiple of UDF_BLOCKSIZE.
+ * Returns true if the position was successfully changed, or false on
+ * any error condition (such as offset out of range or not aligned to
+ * UDF_BLOCKSIZE).
+ */
+bool
+udf_setpos(udf_dirent_t* p_udf_dirent, off_t offset)
+{
+    if (!p_udf_dirent)
+	return false;
+    if (offset % UDF_BLOCKSIZE || offset < 0 || offset > uint64_from_le(p_udf_dirent->fe.info_len))
+	return false;
+    p_udf_dirent->p_udf->i_position = offset;
+    return true;
+}


### PR DESCRIPTION
This patchset adds a new udf_setpos() function call to allow arbitrary reads of UDF files.

This is needed so we can add libcdio support to [wimlib](https://github.com/ebiggers/wimlib) (A proposal for which we have in pbatard/rufus@96996ae1ee1d5f07874fa2c3b2ed83b87b062eb1) to allow the opening of WIM images residing on UDF images (which is what Microsoft uses for all their Windows installation ISOs) without having to go through a costly mount operation.

We also fix a small issue we found in a warning message.