### PR TITLE
Fix buffer overrun for Joliet filenames

### DIFF
--- a/lib/iso9660/iso9660_fs.c
+++ b/lib/iso9660/iso9660_fs.c
@@ -859,6 +859,11 @@ _iso9660_dir_to_statbuf (iso9660_dir_t *p_iso9660_dir,
 
   /* .. string in statbuf is one longer than in p_iso9660_dir's listing '\1' */
   stat_len = sizeof(iso9660_stat_t) + i_fname + 2;
+#ifdef HAVE_JOLIET
+  if (u_joliet_level) {
+    stat_len += i_fname / 2;
+  }
+#endif
 
   /* Reuse multiextent p_stat if not NULL */
   if (!p_stat) {


### PR DESCRIPTION
Joliet uses UCS-2 (2 bytes per character), and converting to UTF-8 may require up to 3 bytes per character. This patch increases the buffer size by i_fname/2 to prevent buffer overrun.