### PR TITLE
Fix ISO 9660 timezone offset signs, add extreme timezone tests.

### DIFF
--- a/lib/iso9660/iso9660.c
+++ b/lib/iso9660/iso9660.c
@@ -383,7 +383,7 @@ iso9660_set_ltime_with_timezone(const struct tm *p_tm,
            0 /* 1/100 secs */ );
 
   /* Set time zone in 15-minute interval encoding. */
-  pvd_date->lt_gmtoff = (time_zone / 15);
+  pvd_date->lt_gmtoff += (time_zone / 15);
   if (pvd_date->lt_gmtoff < -48 ) {
 
     cdio_warn ("Converted ISO 9660 timezone %d is less than -48. Adjusted",


### PR DESCRIPTION
This is a fix for https://github.com/libcdio/libcdio/issues/18.

It turned out that the current ISO 9660 timezone handling is incorrectly reversing the sign of the timezone offset.

ISO 9660 uses a positive offset for east: https://web.archive.org/web/20110717142714/http://alumnus.caltech.edu/~pje/iso9660.html#:~:text=complement%20signed%20number%2C-,positive%20for%20time%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20zones%20east%20of%20Greenwich%2C%20and%20negative%20for%20time%20zones%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20west%20of%20Greenwich,-If%20the%20date

The `tm_gmtoff` member of the `tm` struct also uses a positive offset for east:
https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/time.h.html#:~:text=flag.%0Along%20%20%20%20%20%20%20%20tm_gmtoff-,Seconds%20east%20of%20UTC,-.%0Aconst%20char

The confusion might be due to the `TZ` environment variable under POSIX using the opposite convention:
https://ftp.gnu.org/old-gnu/Manuals/glibc-2.2.3/html_node/libc_431.html#:~:text=This%20is%20positive%20if%20the%20local%20time%20zone%20is%20west%20of%20the%20Prime%20Meridian%20and%20negative%20if%20it%20is%20east.

I also added tests for behavior at the extremes of timezone offsets.

The tests use the functions `setenv()` and `unsetenv()` which are POSIX but not standard C. Can libcdio code assume a POSIX environment or does that need to be wrapped in macros?