### PR TITLE
Fix udf_read_block docs (count blocks, not bytes)

### DIFF
--- a/include/cdio/udf_file.h
+++ b/include/cdio/udf_file.h
@@ -67,23 +67,17 @@ extern "C" {
   udf_dirent_t *udf_opendir(const udf_dirent_t *p_udf_dirent);
   
   /**
-     Attempts to read up to count bytes from UDF directory entry
-     p_udf_dirent into the buffer starting at buf. buf should be a
-     multiple of UDF_BLOCKSIZE bytes. Reading continues after the
-     point at which we last read or from the beginning the first time.
+     Attempts to read up to count blocks from UDF directory entry
+     p_udf_dirent into the buffer starting at buf. buf must be large
+     enough to store count * UDF_BLOCKSIZE bytes. Reading continues after
+     the point at which we last read or from the beginning the first
+     time.
      
      If count is zero, read() returns zero and has no other results. If
      count is greater than SSIZE_MAX, the result is unspecified.
      
-     If there is an error, cast the result to driver_return_code_t for 
-     the specific error code.
-  */
-  /**
-    Attempts to read up to count bytes from file descriptor fd into
-    the buffer starting at buf.
-    
-    If count is zero, read() returns zero and has no other results. If
-    count is greater than SSIZE_MAX, the result is unspecified.
+     On success, returns the number of bytes read. If there is an error,
+     cast the result to driver_return_code_t for the specific error code.
   */
   ssize_t udf_read_block(const udf_dirent_t *p_udf_dirent, 
 			 void * buf, size_t count);

--- a/lib/udf/udf_file.c
+++ b/lib/udf/udf_file.c
@@ -221,9 +221,9 @@ offset_to_lba(const udf_dirent_t *p_udf_dirent, off_t i_offset,
 }
 
 /**
-  Attempts to read up to count bytes from UDF directory entry
-  p_udf_dirent into the buffer starting at buf. buf should be a
-  multiple of UDF_BLOCKSIZE bytes. Reading continues after the point
+  Attempts to read up to count blocks from UDF directory entry
+  p_udf_dirent into the buffer starting at buf. buf must be large enough
+  to store count * UDF_BLOCKSIZE bytes. Reading continues after the point
   at which we last read or from the beginning the first time.
 
   If count is zero, read() returns zero and has no other results. If
@@ -232,8 +232,8 @@ offset_to_lba(const udf_dirent_t *p_udf_dirent, off_t i_offset,
   It is the caller's responsibility to ensure that count is less
   than the number of blocks recorded via p_udf_dirent.
 
-  If there is an error, cast the result to driver_return_code_t for
-  the specific error code.
+  On success, returns the number of bytes read. If there is an error,
+  cast the result to driver_return_code_t for the specific error code.
 */
 ssize_t
 udf_read_block(const udf_dirent_t *p_udf_dirent, void * buf, size_t count)


### PR DESCRIPTION
The `count` argument to `udf_read_block` takes the number of blocks to read, not the number of bytes. (Each block is `UDF_BLOCKSIZE` bytes long.) Reword the documentation comments to reflect this.