### PR TITLE
Fix `-Wdiscarded-qualifiers` warning by retaining const qualifier from pointer

### DIFF
--- a/src/cd-drive.c
+++ b/src/cd-drive.c
@@ -85,8 +85,8 @@ parse_options (int argc, char *argv[])
     {NULL, 0, NULL, 0 }
   };
 
-  program_name = strrchr(argv[0],'/');
-  program_name = program_name ? strdup(program_name+1) : strdup(argv[0]);
+  const char *program_name2 = strrchr(argv[0],'/');
+  program_name = program_name2 ? strdup(program_name2+1) : strdup(argv[0]);
 
   while ((opt = getopt_long(argc, argv, optionsString, optionsTable, NULL)) != -1) {
     switch (opt) {

--- a/src/cd-info.c
+++ b/src/cd-info.c
@@ -307,8 +307,8 @@ parse_options (int argc, char *argv[])
     { NULL, 0, NULL, 0 }
   };
 
-  program_name = strrchr(argv[0],'/');
-  program_name = program_name ? strdup(program_name+1) : strdup(argv[0]);
+  const char *program_name2 = strrchr(argv[0],'/');
+  program_name = program_name2 ? strdup(program_name2+1) : strdup(argv[0]);
 
   while ((opt = getopt_long(argc, argv, optionsString, optionsTable, NULL)) >= 0) {
     switch (opt) {

--- a/src/cd-read.c
+++ b/src/cd-read.c
@@ -311,8 +311,8 @@ parse_options (int argc, char *argv[])
     { NULL, 0, NULL, 0 }
   };
 
-  program_name = strrchr(argv[0],'/');
-  program_name = program_name ? strdup(program_name+1) : strdup(argv[0]);
+  const char *program_name2 = strrchr(argv[0],'/');
+  program_name = program_name2 ? strdup(program_name2+1) : strdup(argv[0]);
 
   while ((opt = getopt_long(argc, argv, optionsString, optionsTable, NULL)) >= 0)
     switch (opt)

--- a/src/cdinfo-linux.c
+++ b/src/cdinfo-linux.c
@@ -680,8 +680,8 @@ main(int argc, char *argv[])
   int fs=0;
   gl_default_log_handler = cdio_log_set_handler (_log_handler);
 
-  program_name = strrchr(argv[0],'/');
-  program_name = program_name ? program_name+1 : argv[0];
+  const char *program_name2 = strrchr(argv[0],'/');
+  program_name = program_name2 ? program_name2+1 : argv[0];
 
   /* Default option values. */
   opts.silent         = false;

--- a/src/iso-info.c
+++ b/src/iso-info.c
@@ -160,8 +160,8 @@ parse_options (int argc, char *argv[])
     { NULL, 0, NULL, 0 }
   };
 
-  program_name = strrchr(argv[0],'/');
-  program_name = program_name ? strdup(program_name+1) : strdup(argv[0]);
+  const char *program_name2 = strrchr(argv[0],'/');
+  program_name = program_name2 ? strdup(program_name2+1) : strdup(argv[0]);
 
   while ((opt = getopt_long(argc, argv, optionsString, optionsTable, NULL)) >= 0) {
     switch (opt)

--- a/src/iso-read.c
+++ b/src/iso-read.c
@@ -115,8 +115,8 @@ parse_options (int argc, char *argv[])
     { NULL, 0, NULL, 0 }
   };
 
-  program_name = strrchr(argv[0],'/');
-  program_name = program_name ? strdup(program_name+1) : strdup(argv[0]);
+  const char *program_name2 = strrchr(argv[0],'/');
+  program_name = program_name2 ? strdup(program_name2+1) : strdup(argv[0]);
 
   while ((opt = getopt_long(argc, argv, optionsString, optionsTable, NULL)) != -1)
     switch (opt)

--- a/src/mmc-tool.c
+++ b/src/mmc-tool.c
@@ -264,9 +264,9 @@ _log_handler (cdio_log_level_t level, const char message[])
 static void
 init(const char *argv0)
 {
+  const char *program_name2 = strrchr(argv0,'/');
+  program_name = program_name2 ? strdup(program_name2+1) : strdup(argv0);
   gl_default_cdio_log_handler = cdio_log_set_handler (_log_handler);
-  program_name = strrchr(argv0,'/');
-  program_name = program_name ? strdup(program_name+1) : strdup(argv0);
 }
 
 static void


### PR DESCRIPTION
Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the in put argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html

fixes:
```c
../../src/mmc-tool.c: In function 'init':
../../src/mmc-tool.c:268:16: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  268 |   program_name = strrchr(argv0,'/');
      |                ^
``` 