### PR TITLE
Use thread locals in recursion check to allow for multi threaded use

### DIFF
--- a/lib/driver/logging.c
+++ b/lib/driver/logging.c
@@ -99,15 +99,9 @@ cdio_logv(cdio_log_level_t level, const char format[], va_list args)
   char buf[1024] = { 0, };
 
   /* _handler() is user defined and we want to make sure _handler()
-  doesn't call us, cdio_logv. in_recursion is used for that, however
-  it has a problem in multi-threaded programs. I'm not sure how to
-  handle multi-threading and recursion checking both. For now, we'll
-  leave in the recursion checking, at the expense of handling
-  multi-threaded log calls. To ameliorate this, we'll check the log
-  level and handle calls where there is no output, before the
-  recursion check.
+     doesn't call us, cdio_logv. in_recursion is used for that.
   */
- static int in_recursion = 0;
+ THREAD_LOCAL int in_recursion = 0;
 
   if (level < cdio_loglevel_default) return;
 

--- a/lib/driver/portable.h
+++ b/lib/driver/portable.h
@@ -51,4 +51,12 @@
 # define drand48()   (rand() / (double)RAND_MAX)
 #endif
 
+#if defined(_MSC_VER)
+# define THREAD_LOCAL static __declspec(thread)
+#elif defined(__GNUC__) || defined(__clang__)
+# define THREAD_LOCAL static __thread
+#else
+# define THREAD_LOCAL
+#endif
+
 #endif /* CDIO_DRIVER_PORTABLE_H_ */


### PR DESCRIPTION
libcdio's log methods have a recursion check that uses a global
static. While originally intended to prevent recursion, it also
introduced a side effect that caused multi threaded programs
to abort due to the check causing an assert call.

Use a thread local static to keep the recursion check and
prevent program abort during multi threaded use.