### PR TITLE
mmc: Fix incorrect allocation len in MMC request

### DIFF
--- a/example/mmc2.c
+++ b/example/mmc2.c
@@ -55,7 +55,7 @@ main(int argc, const char *argv[])
     mmc_cdb_t cdb = {{0, }};   /* Command Descriptor Buffer */
 
     CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_GET_CONFIGURATION);
-    CDIO_MMC_SET_READ_LENGTH8(cdb.field, sizeof(buf));
+    CDIO_MMC_SET_READ_LENGTH16(cdb.field, sizeof(buf));
     cdb.field[1] = CDIO_MMC_GET_CONF_ALL_FEATURES;
     cdb.field[3] = 0x0;
 

--- a/include/cdio/mmc.h
+++ b/include/cdio/mmc.h
@@ -543,9 +543,6 @@ typedef struct mmc_cdb_s {
 #define CDIO_MMC_SET_READ_LENGTH16(cdb, len) \
   CDIO_MMC_SET_LEN16(cdb, 7, len)
 
-#define CDIO_MMC_SET_READ_LENGTH8(cdb, len) \
-  cdb[8] = (len      ) & 0xff
-
 #define CDIO_MMC_MCSB_ALL_HEADERS 0xf
 
 #define CDIO_MMC_SET_MAIN_CHANNEL_SELECTION_BITS(cdb, val) \

--- a/lib/driver/mmc/mmc.c
+++ b/lib/driver/mmc/mmc.c
@@ -629,7 +629,7 @@ mmc_audio_read_subchannel (CdIo_t *p_cdio,  cdio_subchannel_t *p_subchannel)
   memset(&cdb, 0, sizeof(mmc_cdb_t));
 
   CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_READ_SUBCHANNEL);
-  CDIO_MMC_SET_READ_LENGTH8(cdb.field, sizeof(cdio_mmc_subchannel_t));
+  CDIO_MMC_SET_READ_LENGTH16(cdb.field, sizeof(cdio_mmc_subchannel_t));
 
   cdb.field[1] = CDIO_CDROM_MSF;
   cdb.field[2] = 0x40; /* subq */
@@ -774,7 +774,7 @@ mmc_get_discmode( const CdIo_t *p_cdio )
   memset(&cdb, 0, sizeof(mmc_cdb_t));
 
   CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_READ_TOC);
-  CDIO_MMC_SET_READ_LENGTH8(cdb.field, sizeof(buf));
+  CDIO_MMC_SET_READ_LENGTH16(cdb.field, sizeof(buf));
 
   cdb.field[1] = CDIO_CDROM_MSF; /* The MMC-5 spec may require this. */
   cdb.field[2] = CDIO_MMC_READTOC_FMT_FULTOC;
@@ -1188,7 +1188,7 @@ mmc_have_interface( CdIo_t *p_cdio, cdio_mmc_feature_interface_t e_interface )
   if (!p_cdio || !p_cdio->op.run_mmc_cmd) return nope;
 
   CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_GET_CONFIGURATION);
-  CDIO_MMC_SET_READ_LENGTH8(cdb.field, sizeof(buf));
+  CDIO_MMC_SET_READ_LENGTH16(cdb.field, sizeof(buf));
 
   cdb.field[1] = CDIO_MMC_GET_CONF_NAMED_FEATURE;
   cdb.field[3] = CDIO_MMC_FEATURE_CORE;

--- a/lib/driver/mmc/mmc_ll_cmds.c
+++ b/lib/driver/mmc/mmc_ll_cmds.c
@@ -68,7 +68,7 @@ mmc_get_configuration(const CdIo_t *p_cdio, void *p_buf,
 
 {
     MMC_CMD_SETUP(CDIO_MMC_GPCMD_GET_CONFIGURATION);
-    CDIO_MMC_SET_READ_LENGTH8(cdb.field, i_size);
+    CDIO_MMC_SET_READ_LENGTH16(cdb.field, i_size);
     if (0 == i_timeout_ms) i_timeout_ms = mmc_timeout_ms;
     cdb.field[1] = i_return_type & 0x3;
     CDIO_MMC_SET_LEN16(cdb.field, 2, i_starting_feature_number);
@@ -380,7 +380,7 @@ mmc_read_disc_information(const CdIo_t *p_cdio, /*out*/ void *p_buf,
                           unsigned int i_timeout_ms)
 {
     MMC_CMD_SETUP(CDIO_MMC_GPCMD_READ_DISC_INFO);
-    CDIO_MMC_SET_READ_LENGTH8(cdb.field, i_size);
+    CDIO_MMC_SET_READ_LENGTH16(cdb.field, i_size);
     if (0 == i_timeout_ms) i_timeout_ms = mmc_timeout_ms;
     cdb.field[1] = data_type & 0x7;
     return MMC_RUN_CMD(SCSI_MMC_DATA_READ, i_timeout_ms);
@@ -523,7 +523,7 @@ mmc_read_subchannel ( const CdIo_t *p_cdio,
     return DRIVER_OP_BAD_PARAMETER;
 
   CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_READ_SUBCHANNEL);
-  CDIO_MMC_SET_READ_LENGTH8(cdb.field, i_size);
+  CDIO_MMC_SET_READ_LENGTH16(cdb.field, i_size);
 
   if(CDIO_SUBCHANNEL_CURRENT_POSITION == sub_chan_param)
     cdb.field[1] = CDIO_CDROM_MSF;

--- a/src/util.c
+++ b/src/util.c
@@ -195,7 +195,7 @@ print_mmc_drive_features(CdIo_t *p_cdio)
   mmc_cdb_t cdb = {{0, }};       /* Command Descriptor Block */
 
   CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_GET_CONFIGURATION);
-  CDIO_MMC_SET_READ_LENGTH8(cdb.field, sizeof(buf));
+  CDIO_MMC_SET_READ_LENGTH16(cdb.field, sizeof(buf));
   cdb.field[1] = CDIO_MMC_GET_CONF_ALL_FEATURES;
   cdb.field[3] = 0x0;
 


### PR DESCRIPTION
The allocation length (value) of the MMC commands affected by this
patch is 16 bits. However, `CDIO_MMC_SET_READ_LENGTH8` only extracts
8 of the least significant bits of the length value to assign in
the CDB of the MMC request.
Therefore, a buffer length value of say 32768 (i.e 2**15) would be
set as zero, making the MMC request not work as intended.

Fix this by using `CDIO_MMC_SET_READ_LENGTH16` instead.
This makes the prior macro as dead code, thus remove it.

References:
MMC-3 (for deprecated commands): https://archive.org/details/mmc3r10g/
MMC-5: https://www.13thmonkey.org/documentation/SCSI/mmc5r02c.pdf