### PR TITLE
mmc: Deprecate obscure set length macros

### DIFF
--- a/example/mmc2.c
+++ b/example/mmc2.c
@@ -55,7 +55,7 @@ main(int argc, const char *argv[])
     mmc_cdb_t cdb = {{0, }};   /* Command Descriptor Buffer */
 
     CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_GET_CONFIGURATION);
-    CDIO_MMC_SET_READ_LENGTH16(cdb.field, sizeof(buf));
+    CDIO_MMC_SET_LEN16(cdb.field, 7, sizeof(buf));
     cdb.field[1] = CDIO_MMC_GET_CONF_ALL_FEATURES;
     cdb.field[3] = 0x0;
 

--- a/example/read-disc-struct.c
+++ b/example/read-disc-struct.c
@@ -71,7 +71,7 @@ main(int argc, const char *argv[])
     int i;
 
     CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_READ_DVD_STRUCTURE);
-    CDIO_MMC_SET_READ_LENGTH16(cdb.field, sizeof(buf));
+    CDIO_MMC_SET_LEN16(cdb.field, 8, sizeof(buf));
 
     for (i=0; i<=16; i++) {
 	cdb.field[7] = i; /* The format field */

--- a/include/cdio/mmc.h
+++ b/include/cdio/mmc.h
@@ -544,6 +544,10 @@ typedef struct mmc_cdb_s {
 #define CDIO_MMC_SET_READ_LENGTH16(cdb, len) \
   CDIO_MMC_SET_LEN16(cdb, 7, len)
 
+/* @deprecated */
+#define CDIO_MMC_SET_READ_LENGTH8(cdb, len) \
+  cdb[8] = (len      ) & 0xff
+
 #define CDIO_MMC_MCSB_ALL_HEADERS 0xf
 
 #define CDIO_MMC_SET_MAIN_CHANNEL_SELECTION_BITS(cdb, val) \

--- a/include/cdio/mmc.h
+++ b/include/cdio/mmc.h
@@ -540,6 +540,7 @@ typedef struct mmc_cdb_s {
   cdb[7] = (len >>  8) & 0xff; \
   cdb[8] = (len      ) & 0xff
 
+/* @deprecated Use CDIO_MMC_SET_LEN16 instead */
 #define CDIO_MMC_SET_READ_LENGTH16(cdb, len) \
   CDIO_MMC_SET_LEN16(cdb, 7, len)
 

--- a/lib/driver/FreeBSD/freebsd_cam.c
+++ b/lib/driver/FreeBSD/freebsd_cam.c
@@ -208,7 +208,7 @@ read_mode2_sectors_freebsd_cam (_img_private_t *p_env, void *p_buf,
     int retval;
 
     CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_READ_10);
-    CDIO_MMC_SET_READ_LENGTH16(cdb.field, nblocks);
+    CDIO_MMC_SET_LEN16(cdb.field, 7, nblocks);
     if ((retval = mmc_set_blocksize (p_env->gen.cdio, M2RAW_SECTOR_SIZE)))
       return retval;
 

--- a/lib/driver/MSWindows/aspi32.c
+++ b/lib/driver/MSWindows/aspi32.c
@@ -676,7 +676,7 @@ read_toc_aspi (_img_private_t *p_env)
   /* Starting track */
   CDIO_MMC_SET_START_TRACK(cdb.field, 0);
 
-  CDIO_MMC_SET_READ_LENGTH16(cdb.field, sizeof(tocheader));
+  CDIO_MMC_SET_LEN16(cdb.field, 7, sizeof(tocheader));
 
   i_status = run_mmc_cmd_aspi (p_env, OP_TIMEOUT_MS,
                                mmc_get_cmd_len(cdb.field[0]),
@@ -702,7 +702,7 @@ read_toc_aspi (_img_private_t *p_env)
       return false;
     }
 
-    CDIO_MMC_SET_READ_LENGTH16(cdb.field, i_toclength);
+    CDIO_MMC_SET_LEN16(cdb.field, 7, i_toclength);
 
     i_status = run_mmc_cmd_aspi (p_env, OP_TIMEOUT_MS,
                                  mmc_get_cmd_len(cdb.field[0]),

--- a/lib/driver/MSWindows/win32_ioctl.c
+++ b/lib/driver/MSWindows/win32_ioctl.c
@@ -1018,7 +1018,7 @@ read_fulltoc_win32mmc (_img_private_t *p_env)
   memset(&cdrom_toc_full, 0, sizeof(cdrom_toc_full));
 
   /* Setup to read header, to get length of data */
-  CDIO_MMC_SET_READ_LENGTH16(cdb.field, sizeof(cdrom_toc_full));
+  CDIO_MMC_SET_LEN16(cdb.field, 7, sizeof(cdrom_toc_full));
 
   i_status = run_mmc_cmd_win32ioctl (p_env, 1000*60*3,
                                      mmc_get_cmd_len(cdb.field[0]),

--- a/lib/driver/aix.c
+++ b/lib/driver/aix.c
@@ -567,7 +567,7 @@ read_toc_aix (void *p_user_data)
   memset(&cdrom_toc_full, 0, sizeof(cdrom_toc_full));
 
   /* Setup to read header, to get length of data */
-  CDIO_MMC_SET_READ_LENGTH16(cdb.field, sizeof(cdrom_toc_full));
+  CDIO_MMC_SET_LEN16(cdb.field, 7, sizeof(cdrom_toc_full));
 
   i_status = run_scsi_cmd_aix (p_env, 1000*60*3,
                                mmc_get_cmd_len(cdb.field[0]),

--- a/lib/driver/gnu_linux.c
+++ b/lib/driver/gnu_linux.c
@@ -974,7 +974,7 @@ _read_mode2_sectors_mmc (_img_private_t *p_env, void *p_buf, lba_t lba,
     int retval;
 
     CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_READ_10);
-    CDIO_MMC_SET_READ_LENGTH16(cdb.field, i_blocks);
+    CDIO_MMC_SET_LEN16(cdb.field, 7, i_blocks);
 
     if ((retval = mmc_set_blocksize (p_env->gen.cdio, M2RAW_SECTOR_SIZE)))
       return retval;

--- a/lib/driver/mmc/mmc.c
+++ b/lib/driver/mmc/mmc.c
@@ -629,7 +629,7 @@ mmc_audio_read_subchannel (CdIo_t *p_cdio,  cdio_subchannel_t *p_subchannel)
   memset(&cdb, 0, sizeof(mmc_cdb_t));
 
   CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_READ_SUBCHANNEL);
-  CDIO_MMC_SET_READ_LENGTH16(cdb.field, sizeof(cdio_mmc_subchannel_t));
+  CDIO_MMC_SET_LEN16(cdb.field, 7, sizeof(cdio_mmc_subchannel_t));
 
   cdb.field[1] = CDIO_CDROM_MSF;
   cdb.field[2] = 0x40; /* subq */
@@ -737,7 +737,7 @@ mmc_get_disc_last_lsn ( const CdIo_t *p_cdio )
 
   CDIO_MMC_SET_START_TRACK(cdb.field, CDIO_CDROM_LEADOUT_TRACK);
 
-  CDIO_MMC_SET_READ_LENGTH16(cdb.field, sizeof(buf));
+  CDIO_MMC_SET_LEN16(cdb.field, 7, sizeof(buf));
 
   i_status = mmc_run_cmd(p_cdio, mmc_timeout_ms, &cdb, SCSI_MMC_DATA_READ,
                          sizeof(buf), buf);
@@ -774,7 +774,7 @@ mmc_get_discmode( const CdIo_t *p_cdio )
   memset(&cdb, 0, sizeof(mmc_cdb_t));
 
   CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_READ_TOC);
-  CDIO_MMC_SET_READ_LENGTH16(cdb.field, sizeof(buf));
+  CDIO_MMC_SET_LEN16(cdb.field, 7, sizeof(buf));
 
   cdb.field[1] = CDIO_CDROM_MSF; /* The MMC-5 spec may require this. */
   cdb.field[2] = CDIO_MMC_READTOC_FMT_FULTOC;
@@ -1188,7 +1188,7 @@ mmc_have_interface( CdIo_t *p_cdio, cdio_mmc_feature_interface_t e_interface )
   if (!p_cdio || !p_cdio->op.run_mmc_cmd) return nope;
 
   CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_GET_CONFIGURATION);
-  CDIO_MMC_SET_READ_LENGTH16(cdb.field, sizeof(buf));
+  CDIO_MMC_SET_LEN16(cdb.field, 7, sizeof(buf));
 
   cdb.field[1] = CDIO_MMC_GET_CONF_NAMED_FEATURE;
   cdb.field[3] = CDIO_MMC_FEATURE_CORE;

--- a/lib/driver/mmc/mmc_cmd_helper.h
+++ b/lib/driver/mmc/mmc_cmd_helper.h
@@ -35,16 +35,6 @@
                                                                         \
     CDIO_MMC_SET_COMMAND(cdb.field, mmc_cmd)
 
-/* Boilerplate initialization code to setup running MMC read command
-   needs to set the cdb 16-bit length field. See above
-   comment for MMC_CMD_SETUP.
-*/
-#define MMC_CMD_SETUP_READ16(mmc_cmd)                                   \
-    MMC_CMD_SETUP(mmc_cmd);                                             \
-                                                                        \
-    /* Setup to read header, to get length of data */                   \
-    CDIO_MMC_SET_READ_LENGTH16(cdb.field, i_size)
-
 /* Boilerplate code to run a MMC command.
 
    We assume variables 'p_cdio', 'mmc_timeout_ms', 'cdb', 'i_size' and

--- a/lib/driver/mmc/mmc_ll_cmds.c
+++ b/lib/driver/mmc/mmc_ll_cmds.c
@@ -93,7 +93,8 @@ mmc_get_event_status(const CdIo_t *p_cdio, uint8_t out_buf[2])
     const unsigned int i_size = sizeof(buf);
     driver_return_code_t i_status;
 
-    MMC_CMD_SETUP_READ16(CDIO_MMC_GPCMD_GET_EVENT_STATUS);
+    MMC_CMD_SETUP(CDIO_MMC_GPCMD_GET_EVENT_STATUS);
+    CDIO_MMC_SET_LEN16(cdb.field, 7, i_size);
 
     cdb.field[1] = 1;      /* We poll for info */
     cdb.field[4] = 1 << 4; /* We want Media events */
@@ -128,7 +129,9 @@ driver_return_code_t
 mmc_mode_select_10(CdIo_t *p_cdio, /*out*/ void *p_buf, unsigned int i_size,
                    int page, unsigned int i_timeout_ms)
 {
-    MMC_CMD_SETUP_READ16(CDIO_MMC_GPCMD_MODE_SELECT_10);
+    MMC_CMD_SETUP(CDIO_MMC_GPCMD_MODE_SELECT_10);
+    CDIO_MMC_SET_LEN16(cdb.field, 7, i_size);
+
     if (0 == i_timeout_ms) i_timeout_ms = mmc_timeout_ms;
     cdb.field[1] = page;
     return MMC_RUN_CMD(SCSI_MMC_DATA_WRITE, i_timeout_ms);
@@ -147,7 +150,9 @@ driver_return_code_t
 mmc_mode_sense_10(CdIo_t *p_cdio, void *p_buf, unsigned int i_size,
                   unsigned int page)
 {
-    MMC_CMD_SETUP_READ16(CDIO_MMC_GPCMD_MODE_SENSE_10);
+    MMC_CMD_SETUP(CDIO_MMC_GPCMD_MODE_SENSE_10);
+    CDIO_MMC_SET_LEN16(cdb.field, 7, i_size);
+
     cdb.field[2] = CDIO_MMC_ALL_PAGES & page;
     return MMC_RUN_CMD(SCSI_MMC_DATA_READ, mmc_timeout_ms);
 }
@@ -457,7 +462,8 @@ mmc_start_stop_unit(const CdIo_t *p_cdio, bool b_eject, bool b_immediate,
   void * p_buf = &buf;
   const unsigned int i_size = 0;
 
-  MMC_CMD_SETUP_READ16(CDIO_MMC_GPCMD_START_STOP_UNIT);
+  MMC_CMD_SETUP(CDIO_MMC_GPCMD_START_STOP_UNIT);
+  /* this command doesn't have an allocation length in its CDB */
 
   if (b_immediate) cdb.field[1] |= 1;
 
@@ -485,7 +491,9 @@ mmc_test_unit_ready(const CdIo_t *p_cdio, unsigned int i_timeout_ms)
 {
     const unsigned int i_size = 0;
     void  * p_buf = NULL;
-    MMC_CMD_SETUP_READ16(CDIO_MMC_GPCMD_TEST_UNIT_READY);
+
+    MMC_CMD_SETUP(CDIO_MMC_GPCMD_TEST_UNIT_READY);
+    /* this command doesn't have an allocation length in its CDB */
 
     if (0 == i_timeout_ms) i_timeout_ms = mmc_timeout_ms;
     return MMC_RUN_CMD(SCSI_MMC_DATA_NONE, i_timeout_ms);

--- a/lib/driver/mmc/mmc_ll_cmds.c
+++ b/lib/driver/mmc/mmc_ll_cmds.c
@@ -68,7 +68,7 @@ mmc_get_configuration(const CdIo_t *p_cdio, void *p_buf,
 
 {
     MMC_CMD_SETUP(CDIO_MMC_GPCMD_GET_CONFIGURATION);
-    CDIO_MMC_SET_READ_LENGTH16(cdb.field, i_size);
+    CDIO_MMC_SET_LEN16(cdb.field, 7, i_size);
     if (0 == i_timeout_ms) i_timeout_ms = mmc_timeout_ms;
     cdb.field[1] = i_return_type & 0x3;
     CDIO_MMC_SET_LEN16(cdb.field, 2, i_starting_feature_number);
@@ -385,7 +385,7 @@ mmc_read_disc_information(const CdIo_t *p_cdio, /*out*/ void *p_buf,
                           unsigned int i_timeout_ms)
 {
     MMC_CMD_SETUP(CDIO_MMC_GPCMD_READ_DISC_INFO);
-    CDIO_MMC_SET_READ_LENGTH16(cdb.field, i_size);
+    CDIO_MMC_SET_LEN16(cdb.field, 7, i_size);
     if (0 == i_timeout_ms) i_timeout_ms = mmc_timeout_ms;
     cdb.field[1] = data_type & 0x7;
     return MMC_RUN_CMD(SCSI_MMC_DATA_READ, i_timeout_ms);
@@ -531,7 +531,7 @@ mmc_read_subchannel ( const CdIo_t *p_cdio,
     return DRIVER_OP_BAD_PARAMETER;
 
   CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_READ_SUBCHANNEL);
-  CDIO_MMC_SET_READ_LENGTH16(cdb.field, i_size);
+  CDIO_MMC_SET_LEN16(cdb.field, 7, i_size);
 
   if(CDIO_SUBCHANNEL_CURRENT_POSITION == sub_chan_param)
     cdb.field[1] = CDIO_CDROM_MSF;
@@ -578,7 +578,7 @@ mmc_read_toc_cdtext ( const CdIo_t *p_cdio, unsigned int *i_length,
     return DRIVER_OP_BAD_PARAMETER;
 
   CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_READ_TOC);
-  CDIO_MMC_SET_READ_LENGTH16(cdb.field, i_size);
+  CDIO_MMC_SET_LEN16(cdb.field, 7, i_size);
 
   memset(p_buf, 0, i_size);
 

--- a/src/util.c
+++ b/src/util.c
@@ -195,7 +195,7 @@ print_mmc_drive_features(CdIo_t *p_cdio)
   mmc_cdb_t cdb = {{0, }};       /* Command Descriptor Block */
 
   CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_GET_CONFIGURATION);
-  CDIO_MMC_SET_READ_LENGTH16(cdb.field, sizeof(buf));
+  CDIO_MMC_SET_LEN16(cdb.field, 7, sizeof(buf));
   cdb.field[1] = CDIO_MMC_GET_CONF_ALL_FEATURES;
   cdb.field[3] = 0x0;
 


### PR DESCRIPTION
These macros set the allocation length at fixed positions in the CDB (namely bytes 7 and 8). Not all MMC commands use these positions, e.g. `READ DVD STRUCTURE` expects it at bytes 8 and 9.
This is prone to misuse because of their hard coded nature, causing #58.

Deprecate the public macros, and remove the private macros.

fixes #58