### PR TITLE
Change MMC5 references to MMC6 2g when possible.

### DIFF
--- a/example/audio.c
+++ b/example/audio.c
@@ -104,7 +104,7 @@ oops(const char *psz_msg, int rc)
 
 /* ---------------------------------------------------------------------- */
 
-/*! Stop playing audio CD */
+/** Stop playing audio CD */
 static bool
 cd_stop(CdIo_t *p_cdio)
 {
@@ -118,7 +118,7 @@ cd_stop(CdIo_t *p_cdio)
   return b_ok;
 }
 
-/*! Eject CD */
+/** Eject CD */
 static bool
 cd_eject(void)
 {
@@ -134,7 +134,7 @@ cd_eject(void)
   return b_ok;
 }
 
-/*! Close CD tray */
+/** Close CD tray */
 static bool
 cd_close(const char *psz_device)
 {
@@ -147,7 +147,7 @@ cd_close(const char *psz_device)
   return b_ok;
 }
 
-/*! Pause playing audio CD */
+/** Pause playing audio CD */
 static bool
 cd_pause(CdIo_t *p_cdio)
 {
@@ -160,7 +160,7 @@ cd_pause(CdIo_t *p_cdio)
   return b_ok;
 }
 
-/*! Get status/track/position info of an audio CD */
+/** Get status/track/position info of an audio CD */
 static bool
 read_subchannel(CdIo_t *p_cdio)
 {
@@ -177,7 +177,7 @@ read_subchannel(CdIo_t *p_cdio)
   return b_ok;
 }
 
-/*! Read CD TOC  and set CD information. */
+/** Read CD TOC  and set CD information. */
 static void
 read_toc(CdIo_t *p_cdio)
 {
@@ -224,7 +224,7 @@ read_toc(CdIo_t *p_cdio)
   }
 }
 
-/*! Play an audio track. */
+/** Play an audio track. */
 static bool
 play_track(track_t i_start_track, track_t i_end_track)
 {

--- a/include/cdio++/cdtext.hpp
+++ b/include/cdio++/cdtext.hpp
@@ -21,7 +21,7 @@
  *  should not be #included directly.
  */
 
-/*! Return string representation of the enum values above */
+/** Return string representation of the enum values above */
 const char *field2str (cdtext_field_t i)
 {
   return cdtext_field2str (i);
@@ -37,7 +37,7 @@ const char *lang2str (cdtext_lang_t i)
   return cdtext_lang2str (i);
 }
 
-/*! returns an allocated string associated with the given field.  NULL is
+/** returns an allocated string associated with the given field.  NULL is
   returned if key is CDTEXT_INVALID or the field is not set.
 
   The user needs to free the string using cdio_free() when done with it.
@@ -51,7 +51,7 @@ char *get (cdtext_field_t key, track_t i_track)
   return cdtext_get (p_cdtext, key, i_track);
 }
 
-/*! returns a const string associated with the given field.  NULL is
+/** returns a const string associated with the given field.  NULL is
   returned if key is CDTEXT_INVALID or the field is not set.
 
   Don't use the string when the cdtext object (i.e. the CdIo_t object
@@ -66,7 +66,7 @@ const char *getConst (cdtext_field_t key, track_t i_track)
   return cdtext_get_const (p_cdtext, key, i_track);
 }
 
-/*!
+/**
   sets cdtext's keyword entry to field
 */
 void set (cdtext_field_t key, track_t i_track, const uint8_t *value, const char *charset)
@@ -74,7 +74,7 @@ void set (cdtext_field_t key, track_t i_track, const uint8_t *value, const char 
   cdtext_set (p_cdtext, key, value, i_track, charset);
 }
 
-/*!
+/**
   returns the selected language
 */
 cdtext_lang_t getLanguage()
@@ -82,7 +82,7 @@ cdtext_lang_t getLanguage()
   return cdtext_get_language(p_cdtext);
 }
 
-/*!
+/**
   selects a language
 */
 bool selectLanguage(cdtext_lang_t lang)
@@ -90,7 +90,7 @@ bool selectLanguage(cdtext_lang_t lang)
   return cdtext_select_language(p_cdtext, lang);
 }
 
-/*!
+/**
   selects a language by index rather than language code
 */
 bool setLanguageIndex(int idx)
@@ -98,7 +98,7 @@ bool setLanguageIndex(int idx)
   return cdtext_set_language_index(p_cdtext, idx);
 }
 
-/*!
+/**
 
   @deprecated. Use listLanguagesV2(), see cdio/cdtext.h
 
@@ -109,7 +109,7 @@ cdtext_lang_t *listLanguages()
   return cdtext_list_languages(p_cdtext);
 }
 
-/*!
+/**
   returns a pointer to an array with 8 elements which indicate available
   languages
 */

--- a/include/cdio++/device.hpp
+++ b/include/cdio++/device.hpp
@@ -17,15 +17,15 @@
 
 /** \file device.hpp
  *
- *  \brief C++ header for driver- or device-related libcdio calls.  
+ *  \brief C++ header for driver- or device-related libcdio calls.
  *         ("device" includes CD-image reading devices.)
  */
 
-/*! 
-  Free resources associated with CD-ROM Device/Image. After this we 
+/**
+  Free resources associated with CD-ROM Device/Image. After this we
   must do another open before any more reading.
 */
-bool 
+bool
 close()
 {
   cdio_destroy(p_cdio);
@@ -33,46 +33,46 @@ close()
   return true;
 }
 
-/*!
-  Eject media in CD drive if there is a routine to do so. 
-  
+/**
+  Eject media in CD drive if there is a routine to do so.
+
   If the CD is ejected, object is destroyed.
 */
 void
-ejectMedia () 
+ejectMedia ()
 {
   driver_return_code_t drc = cdio_eject_media(&p_cdio);
   possible_throw_device_exception(drc);
 }
 
-/*!
+/**
   Free device list returned by GetDevices
-  
+
   @param device_list list returned by GetDevices
-  
+
   @see GetDevices
-  
+
 */
-void 
-freeDeviceList (char * device_list[]) 
+void
+freeDeviceList (char * device_list[])
 {
   cdio_free_device_list(device_list);
 }
 
-/*!
-    Get the value associatied with key. 
-    
+/**
+    Get the value associatied with key.
+
     @param key the key to retrieve
     @return the value associatd with "key" or NULL if p_cdio is NULL
     or "key" does not exist.
   */
-const char * 
-getArg (const char key[]) 
+const char *
+getArg (const char key[])
 {
   return cdio_get_arg (p_cdio, key);
 }
 
-/*!  
+/**
   Return an opaque CdIo_t pointer for the given track object.
 */
 CdIo_t *getCdIo()
@@ -80,116 +80,116 @@ CdIo_t *getCdIo()
   return p_cdio;
 }
 
-/*!
+/**
   Get the CD device name for the object.
-  
+
   @return a string containing the CD device for this object or NULL is
   if we couldn't get a device anme.
-  
+
   In some situations of drivers or OS's we can't find a CD device if
   there is no media in it and it is possible for this routine to return
   NULL even though there may be a hardware CD-ROM.
 */
 char *
-getDevice () 
+getDevice ()
 {
   return cdio_get_default_device(p_cdio);
 }
 
-/*!
+/**
   Get the what kind of device we've got.
-  
+
   @param p_read_cap pointer to return read capabilities
   @param p_write_cap pointer to return write capabilities
   @param p_misc_cap pointer to return miscellaneous other capabilities
-  
+
   In some situations of drivers or OS's we can't find a CD device if
   there is no media in it and it is possible for this routine to return
   NULL even though there may be a hardware CD-ROM.
 */
-void 
+void
 getDriveCap (cdio_drive_read_cap_t  &read_cap,
              cdio_drive_write_cap_t &write_cap,
-             cdio_drive_misc_cap_t  &misc_cap) 
+             cdio_drive_misc_cap_t  &misc_cap)
 {
   cdio_get_drive_cap(p_cdio, &read_cap, &write_cap, &misc_cap);
 }
 
-/*!
+/**
   Get a string containing the name of the driver in use.
-  
+
   @return a string with driver name or NULL if CdIo_t is NULL (we
   haven't initialized a specific device.
 */
 const char *
-getDriverName () 
+getDriverName ()
 {
   return cdio_get_driver_name(p_cdio);
 }
 
-/*!
-  Get the driver id. 
-  if CdIo_t is NULL (we haven't initialized a specific device driver), 
+/**
+  Get the driver id.
+  if CdIo_t is NULL (we haven't initialized a specific device driver),
   then return DRIVER_UNKNOWN.
-  
+
   @return the driver id..
 */
-driver_id_t 
-getDriverId () 
+driver_id_t
+getDriverId ()
 {
   return cdio_get_driver_id(p_cdio);
 }
 
-/*! 
+/**
   Get the CD-ROM hardware info via a SCSI MMC INQUIRY command.
   False is returned if we had an error getting the information.
 */
-bool 
-getHWinfo ( /*out*/ cdio_hwinfo_t &hw_info ) 
+bool
+getHWinfo ( /*out*/ cdio_hwinfo_t &hw_info )
 {
   return cdio_get_hwinfo(p_cdio, &hw_info);
 }
 
-/*! Get the LSN of the first track of the last session of
+/** Get the LSN of the first track of the last session of
   on the CD.
-  
+
   @param i_last_session pointer to the session number to be returned.
 */
 void
-getLastSession (/*out*/ lsn_t &i_last_session) 
+getLastSession (/*out*/ lsn_t &i_last_session)
 {
   driver_return_code_t drc = cdio_get_last_session(p_cdio, &i_last_session);
   possible_throw_device_exception(drc);
 }
 
-/*! 
+/**
   Find out if media has changed since the last call.
   @return 1 if media has changed since last call, 0 if not. Error
   return codes are the same as driver_return_code_t
 */
-int 
-getMediaChanged() 
+int
+getMediaChanged()
 {
   return cdio_get_media_changed(p_cdio);
 }
 
-/*! True if CD-ROM understand ATAPI commands. */
-bool_3way_t 
+/** True if CD-ROM understand ATAPI commands. */
+bool_3way_t
 haveATAPI ()
 {
   return cdio_have_atapi(p_cdio);
 }
 
-/*! 
+/**
 
   Sets up to read from the device specified by psz_source.  An open
   routine should be called before using any read routine. If device
   object was previously opened it is closed first.
-  
+
   @return true if open succeeded or false if error.
 
 */
-bool 
+bool
 open(const char *psz_source)
 {
   if (p_cdio) cdio_destroy(p_cdio);
@@ -197,28 +197,28 @@ open(const char *psz_source)
   return NULL != p_cdio ;
 }
 
-/*! 
+/**
 
   Sets up to read from the device specified by psz_source and access
   mode.  An open routine should be called before using any read
   routine. If device object was previously opened it is "closed".
-  
+
   @return true if open succeeded or false if error.
 */
-bool 
-open (const char *psz_source, driver_id_t driver_id, 
-      const char *psz_access_mode = (const char *) NULL) 
+bool
+open (const char *psz_source, driver_id_t driver_id,
+      const char *psz_access_mode = (const char *) NULL)
 {
   if (p_cdio) cdio_destroy(p_cdio);
   if (psz_access_mode)
     p_cdio = cdio_open_am(psz_source, driver_id, psz_access_mode);
-  else 
+  else
     p_cdio = cdio_open(psz_source, driver_id);
   return NULL != p_cdio ;
 }
 
-/*!
-  Set the blocksize for subsequent reads. 
+/**
+  Set the blocksize for subsequent reads.
 */
 void
 setBlocksize ( int i_blocksize )
@@ -227,24 +227,24 @@ setBlocksize ( int i_blocksize )
   possible_throw_device_exception(drc);
 }
 
-/*!
-    Set the drive speed. 
+/**
+    Set the drive speed.
 */
 void
-setSpeed ( int i_speed ) 
+setSpeed ( int i_speed )
 {
   driver_return_code_t drc = cdio_set_speed ( p_cdio, i_speed );
   possible_throw_device_exception(drc);
 }
 
-/*!
+/**
     Set the arg "key" with "value" in "p_cdio".
-    
+
     @param key the key to set
     @param value the value to assocaiate with key
 */
 void
-setArg (const char key[], const char value[]) 
+setArg (const char key[], const char value[])
 {
   driver_return_code_t drc = cdio_set_arg (p_cdio, key, value);
   possible_throw_device_exception(drc);

--- a/include/cdio++/devices.hpp
+++ b/include/cdio++/devices.hpp
@@ -17,14 +17,14 @@
 
 /** \file devices.hpp
  *
- *  \brief methods relating to devices. It is *not* part of a class. 
+ *  \brief methods relating to devices. It is *not* part of a class.
  *  This file should not be #included directly.
  */
 
 
-/*!
-  Close media tray in CD drive if there is a routine to do so. 
-  
+/**
+  Close media tray in CD drive if there is a routine to do so.
+
   @param psz_drive the name of CD-ROM to be closed.
   @param driver_id is the driver to be used or that got used if
   it was DRIVER_UNKNOWN or DRIVER_DEVICE; If this is NULL, we won't
@@ -32,62 +32,62 @@
 */
 void closeTray(const char *psz_drive, /*in/out*/ driver_id_t &driver_id);
 
-/*!
-  Close media tray in CD drive if there is a routine to do so. 
-  
-  @param psz_drive the name of CD-ROM to be closed. If omitted or 
+/**
+  Close media tray in CD drive if there is a routine to do so.
+
+  @param psz_drive the name of CD-ROM to be closed. If omitted or
   NULL, we'll scan for a suitable CD-ROM.
 */
 void closeTray(const char *psz_drive=(const char *)NULL);
 
-/*! 
-  Get a string decribing driver_id. 
-  
+/**
+  Get a string decribing driver_id.
+
   @param driver_id the driver you want the description for
   @return a sring of driver description
 */
 const char *driverDescribe(driver_id_t driver_id);
 
-/*!
-  Eject media in CD drive if there is a routine to do so. 
-  
+/**
+  Eject media in CD drive if there is a routine to do so.
+
   If the CD is ejected, object is destroyed.
 */
 void ejectMedia(const char *psz_drive);
 
-/*!
+/**
   Free device list returned by GetDevices
-  
+
   @param device_list list returned by GetDevices
-  
+
   @see GetDevices
-  
+
 */
 void freeDeviceList(char * device_list[]);
 
-/*!
+/**
   Return a string containing the default CD device if none is specified.
   if p_driver_id is DRIVER_UNKNOWN or DRIVER_DEVICE
   then find a suitable one set the default device for that.
-  
+
   NULL is returned if we couldn't get a default device.
 */
 char * getDefaultDevice(/*in/out*/ driver_id_t &driver_id);
 
-/*! Return an array of device names. If you want a specific
+/** Return an array of device names. If you want a specific
   devices for a driver, give that device. If you want hardware
   devices, give DRIVER_DEVICE and if you want all possible devices,
   image drivers and hardware drivers give DRIVER_UNKNOWN.
-  
+
   NULL is returned if we couldn't return a list of devices.
-  
+
   In some situations of drivers or OS's we can't find a CD device if
   there is no media in it and it is possible for this routine to return
   NULL even though there may be a hardware CD-ROM.
 */
 char ** getDevices(driver_id_t driver_id=DRIVER_DEVICE);
 
-/*! Like GetDevices above, but we may change the p_driver_id if we
+/** Like GetDevices above, but we may change the p_driver_id if we
   were given DRIVER_DEVICE or DRIVER_UNKNOWN. This is because
   often one wants to get a drive name and then *open* it
   afterwards. Giving the driver back facilitates this, and speeds
@@ -96,18 +96,18 @@ char ** getDevices(driver_id_t driver_id=DRIVER_DEVICE);
 
 char **getDevices(driver_id_t &driver_id);
 
-/*!
+/**
   Get an array of device names in search_devices that have at least
   the capabilities listed by the capabities parameter.  If
   search_devices is NULL, then we'll search all possible CD drives.
-  
+
   If "b_any" is set false then every capability listed in the
   extended portion of capabilities (i.e. not the basic filesystem)
   must be satisified. If "any" is set true, then if any of the
   capabilities matches, we call that a success.
-  
+
   To find a CD-drive of any type, use the mask CDIO_FS_MATCH_ALL.
-  
+
   @return the array of device names or NULL if we couldn't get a
   default device.  It is also possible to return a non NULL but
   after dereferencing the the value is NULL. This also means nothing
@@ -116,7 +116,7 @@ char **getDevices(driver_id_t &driver_id);
 char ** getDevices(/*in*/ char *ppsz_search_devices[],
                    cdio_fs_anal_t capabilities, bool b_any=false);
 
-/*!
+/**
   Like GetDevices above but we return the driver we found
   as well. This is because often one wants to search for kind of drive
   and then *open* it afterwards. Giving the driver back facilitates this,
@@ -126,10 +126,10 @@ char ** getDevices(/*in*/ char* ppsz_search_devices[],
                    cdio_fs_anal_t capabilities, /*out*/ driver_id_t &driver_id,
                    bool b_any=false);
 
-/*! Return true if we Have driver for driver_id */
+/** Return true if we Have driver for driver_id */
 bool haveDriver(driver_id_t driver_id);
 
-/*! 
+/**
 
 Determine if bin_name is the bin file part of  a CDRWIN CD disk image.
 
@@ -139,38 +139,38 @@ Determine if bin_name is the bin file part of  a CDRWIN CD disk image.
   */
 char *isBinFile(const char *psz_bin_name);
 
-  
-/*! 
+
+/**
     Determine if cue_name is the cue sheet for a CDRWIN CD disk image.
-    
+
     @return corresponding BIN file if cue_name is a CDRWIN cue file or
     NULL if not a CUE file.
   */
 char *isCueFile(const char *psz_cue_name);
-  
-/*! 
+
+/**
     Determine if psz_source refers to a real hardware CD-ROM.
-    
+
     @param psz_source location name of object
     @param driver_id   driver for reading object. Use DRIVER_UNKNOWN if you
     don't know what driver to use.
     @return true if psz_source is a device; If false is returned we
-    could have a CD disk image. 
+    could have a CD disk image.
 */
 bool isDevice(const char *psz_source, driver_id_t driver_id);
 
-/*! 
+/**
     Determine if psz_nrg is a Nero CD disk image.
-    
+
     @param psz_nrg location of presumed NRG image file.
     @return true if psz_nrg is a Nero NRG image or false
     if not a NRG image.
 */
 bool isNero(const char *psz_nrg);
 
-/*! 
+/**
   Determine if psz_toc is a TOC file for a cdrdao CD disk image.
-  
+
   @param psz_toc location of presumed TOC image file.
   @return true if toc_name is a cdrdao TOC file or false
   if not a TOC file.

--- a/include/cdio++/disc.hpp
+++ b/include/cdio++/disc.hpp
@@ -20,140 +20,140 @@
  *  should not be #included directly.
  */
 
-/*! 
+/**
   Get disc mode - the kind of CD (CD-DA, CD-ROM mode 1, CD-MIXED, etc.
   that we've got. The notion of "CD" is extended a little to include
   DVD's.
 */
-discmode_t getDiscmode () 
+discmode_t getDiscmode ()
 {
   return cdio_get_discmode(p_cdio);
 }
 
-/*!  
+/**
   Get the lsn of the end of the CD
-  
+
   @return the lsn. On error 0 or CDIO_INVALD_LSN.
 */
-lsn_t getDiscLastLsn() 
+lsn_t getDiscLastLsn()
 {
   return cdio_get_disc_last_lsn(p_cdio);
 }
 
-/*!
-  Get the number of the first track. 
-  
+/**
+  Get the number of the first track.
+
   @return a track object or NULL;
   on error.
 */
-CdioTrack *getFirstTrack() 
+CdioTrack *getFirstTrack()
 {
   track_t i_track = cdio_get_first_track_num(p_cdio);
-  return (CDIO_INVALID_TRACK != i_track) 
+  return (CDIO_INVALID_TRACK != i_track)
     ? new CdioTrack(p_cdio, i_track)
     : (CdioTrack *) NULL;
 }
 
-/*!
-  Get the number of the first track. 
-  
-  @return the track number or CDIO_INVALID_TRACK 
+/**
+  Get the number of the first track.
+
+  @return the track number or CDIO_INVALID_TRACK
   on error.
 */
-track_t getFirstTrackNum() 
+track_t getFirstTrackNum()
 {
   return cdio_get_first_track_num(p_cdio);
 }
 
 
-/*!
-  Get the number of the first track. 
-  
+/**
+  Get the number of the first track.
+
   @return a track object or NULL;
   on error.
 */
-CdioTrack *getLastTrack() 
+CdioTrack *getLastTrack()
 {
   track_t i_track = cdio_get_last_track_num(p_cdio);
-  return (CDIO_INVALID_TRACK != i_track) 
+  return (CDIO_INVALID_TRACK != i_track)
     ? new CdioTrack(p_cdio, i_track)
     : (CdioTrack *) NULL;
 }
 
-/*!
-  Get the number of the first track. 
-  
-  @return the track number or CDIO_INVALID_TRACK 
+/**
+  Get the number of the first track.
+
+  @return the track number or CDIO_INVALID_TRACK
   on error.
 */
-track_t getLastTrackNum() 
+track_t getLastTrackNum()
 {
   return cdio_get_last_track_num(p_cdio);
 }
 
-/*!  
+/**
   Return the Joliet level recognized for p_cdio.
 */
-uint8_t getJolietLevel() 
+uint8_t getJolietLevel()
 {
   return cdio_get_joliet_level(p_cdio);
 }
 
-/*!
+/**
   Get the media catalog number (MCN) from the CD.
-  
+
   @return the media catalog number r NULL if there is none or we
   don't have the ability to get it.
-  
+
   Note: The caller must free the returned string with cdio_free()
   when done with it.
-  
+
 */
-char * getMcn () 
+char * getMcn ()
 {
   return cdio_get_mcn (p_cdio);
 }
 
-/*!
+/**
   Get the number of tracks on the CD.
-  
+
   @return the number of tracks, or CDIO_INVALID_TRACK if there is
   an error.
 */
-track_t getNumTracks () 
+track_t getNumTracks ()
 {
   return cdio_get_num_tracks(p_cdio);
 }
 
-/*! Find the track which contans lsn.
+/** Find the track which contans lsn.
   CDIO_INVALID_TRACK is returned if the lsn outside of the CD or
-  if there was some error. 
-  
+  if there was some error.
+
   If the lsn is before the pregap of the first track 0 is returned.
   Otherwise we return the track that spans the lsn.
 */
-CdioTrack *getTrackFromNum(track_t i_track) 
+CdioTrack *getTrackFromNum(track_t i_track)
 {
   return new CdioTrack(p_cdio, i_track);
 }
 
-/*! Find the track which contans lsn.
+/** Find the track which contans lsn.
   CDIO_INVALID_TRACK is returned if the lsn outside of the CD or
-  if there was some error. 
-  
+  if there was some error.
+
   If the lsn is before the pregap of the first track 0 is returned.
   Otherwise we return the track that spans the lsn.
 */
-CdioTrack *getTrackFromLsn(lsn_t lsn) 
+CdioTrack *getTrackFromLsn(lsn_t lsn)
 {
   track_t i_track = cdio_get_track(p_cdio, lsn);
-  return (CDIO_INVALID_TRACK != i_track) 
+  return (CDIO_INVALID_TRACK != i_track)
     ? new CdioTrack(p_cdio, i_track)
     : (CdioTrack *) NULL;
 }
 
 
-/*! 
+/**
   Return true if discmode is some sort of CD.
 */
 bool isDiscmodeCdrom (discmode_t discmode) {
@@ -161,15 +161,15 @@ bool isDiscmodeCdrom (discmode_t discmode) {
 }
 
 
-/*! 
+/**
   Return true if discmode is some sort of DVD.
 */
-bool isDiscmodeDvd (discmode_t discmode) 
+bool isDiscmodeDvd (discmode_t discmode)
 {
   return cdio_is_discmode_dvd (discmode) ;
 }
 
-/*! 
+/**
   Get CD-Text information for a CdIo_t object.
 
   @return the CD-Text object or NULL if obj is NULL
@@ -184,4 +184,3 @@ CdioCDText *getCdtext ()
   else
     return new CdioCDText(cdtext);
 }
-

--- a/include/cdio++/iso9660.hpp
+++ b/include/cdio++/iso9660.hpp
@@ -54,7 +54,7 @@ public:
       std::memcpy(&pvd, p_new_pvd, sizeof(pvd));
     };
 
-    /*!
+    /**
       Return the PVD's application ID.
       NULL is returned if there is some problem in getting this.
     */
@@ -62,13 +62,13 @@ public:
 
     int get_pvd_block_size();
 
-    /*!
+    /**
       Return the PVD's preparer ID.
       NULL is returned if there is some problem in getting this.
     */
     char * get_preparer_id();
 
-    /*!
+    /**
       Return the PVD's publisher ID.
       NULL is returned if there is some problem in getting this.
     */
@@ -80,29 +80,29 @@ public:
 
     uint8_t get_pvd_type();
 
-    /*! Return the primary volume id version number (of pvd).
+    /** Return the primary volume id version number (of pvd).
       If there is an error 0 is returned.
     */
     int get_pvd_version();
 
-    /*! Return the LSN of the root directory for pvd.
+    /** Return the LSN of the root directory for pvd.
       If there is an error CDIO_INVALID_LSN is returned.
     */
     lsn_t get_root_lsn();
 
-    /*!
+    /**
       Return the PVD's system ID.
       NULL is returned if there is some problem in getting this.
     */
     char * get_system_id();
 
-    /*!
+    /**
       Return the PVD's volume ID.
       NULL is returned if there is some problem in getting this.
     */
     char * get_volume_id();
 
-    /*!
+    /**
       Return the PVD's volumeset ID.
       NULL is returned if there is some problem in getting this.
     */
@@ -155,7 +155,7 @@ public:
 
     typedef std::vector< ISO9660::Stat *> stat_vector_t;
 
-    /*!
+    /**
       Given a directory pointer, find the filesystem entry that contains
       lsn and return information about it.
 
@@ -164,25 +164,25 @@ public:
     */
     Stat *find_lsn(lsn_t i_lsn);
 
-    /*! Read the Primary Volume Descriptor for a CD.  A
+    /** Read the Primary Volume Descriptor for a CD.  A
       PVD object is returned if read, and NULL if there was an error.
     */
     PVD *read_pvd ();
 
-    /*!
+    /**
       Read the Super block of an ISO 9660 image. This is the
       Primary Volume Descriptor (PVD) and perhaps a Supplemental Volume
       Descriptor if (Joliet) extensions are acceptable.
     */
     bool read_superblock (iso_extension_mask_t iso_extension_mask);
 
-    /*! Read psz_path (a directory) and return a vector of iso9660_stat_t
+    /** Read psz_path (a directory) and return a vector of iso9660_stat_t
       pointers for the files inside that directory. The caller must free the
       returned result.
     */
     bool readdir (const char psz_path[], stat_vector_t& stat_vector);
 
-    /*!
+    /**
       Return file status for path name psz_path. NULL is returned on
       error.
 
@@ -220,7 +220,7 @@ public:
       p_iso9660 = (iso9660_t *) NULL;
     };
 
-    /*! Close previously opened ISO 9660 image and free resources
+    /** Close previously opened ISO 9660 image and free resources
       associated with the image. Call this when done using using an ISO
       9660 image.
 
@@ -229,7 +229,7 @@ public:
     */
     bool close();
 
-    /*!
+    /**
       Given a directory pointer, find the filesystem entry that contains
       lsn and return information about it.
 
@@ -238,7 +238,7 @@ public:
     */
     Stat *find_lsn(lsn_t i_lsn);
 
-    /*!
+    /**
       Get the application ID.  psz_app_id is set to NULL if there
       is some problem in getting this and false is returned.
     */
@@ -247,12 +247,12 @@ public:
       return iso9660_ifs_get_application_id(p_iso9660, &psz_app_id);
     }
 
-    /*!
+    /**
       Return the Joliet level recognized.
     */
     uint8_t get_joliet_level();
 
-    /*!
+    /**
       Get the preparer ID.  psz_preparer_id is set to NULL if there
       is some problem in getting this and false is returned.
     */
@@ -261,7 +261,7 @@ public:
       return iso9660_ifs_get_preparer_id(p_iso9660, &psz_preparer_id);
     }
 
-    /*!
+    /**
       Get the publisher ID.  psz_publisher_id is set to NULL if there
       is some problem in getting this and false is returned.
     */
@@ -270,7 +270,7 @@ public:
       return iso9660_ifs_get_publisher_id(p_iso9660, &psz_publisher_id);
     }
 
-    /*!
+    /**
       Get the system ID.  psz_system_id is set to NULL if there
       is some problem in getting this and false is returned.
     */
@@ -279,7 +279,7 @@ public:
       return iso9660_ifs_get_system_id(p_iso9660, &psz_system_id);
     }
 
-    /*! Return the volume ID in the PVD. psz_volume_id is set to
+    /** Return the volume ID in the PVD. psz_volume_id is set to
       NULL if there is some problem in getting this and false is
       returned.
     */
@@ -288,7 +288,7 @@ public:
       return iso9660_ifs_get_volume_id(p_iso9660, &psz_volume_id);
     }
 
-    /*! Return the volumeset ID in the PVD. psz_volumeset_id is set to
+    /** Return the volumeset ID in the PVD. psz_volumeset_id is set to
       NULL if there is some problem in getting this and false is
       returned.
     */
@@ -297,12 +297,12 @@ public:
       return iso9660_ifs_get_volumeset_id(p_iso9660, &psz_volumeset_id);
     }
 
-    /*!
+    /**
       Return true if ISO 9660 image has extended attrributes (XA).
     */
     bool is_xa ();
 
-    /*! Open an ISO 9660 image for reading. Maybe in the future we will
+    /** Open an ISO 9660 image for reading. Maybe in the future we will
       have a mode. NULL is returned on error. An open routine should be
       called before using any read routine. If device object was
       previously opened it is closed first.
@@ -323,7 +323,7 @@ public:
       return NULL != (iso9660_t *) p_iso9660 ;
     }
 
-    /*! Open an ISO 9660 image for "fuzzy" reading. This means that we
+    /** Open an ISO 9660 image for "fuzzy" reading. This means that we
       will try to guess various internal offset based on internal
       checks. This may be useful when trying to read an ISO 9660 image
       contained in a file format that libiso9660 doesn't know natively
@@ -339,12 +339,12 @@ public:
                      =ISO_EXTENSION_NONE,
                      uint16_t i_fuzz=20);
 
-    /*! Read the Primary Volume Descriptor for an ISO 9660 image.  A
+    /** Read the Primary Volume Descriptor for an ISO 9660 image.  A
       PVD object is returned if read, and NULL if there was an error.
     */
     PVD *read_pvd ();
 
-    /*!
+    /**
       Read the Super block of an ISO 9660 image but determine framesize
       and datastart and a possible additional offset. Generally here we are
       not reading an ISO 9660 image but a CD-Image which contains an ISO 9660
@@ -356,7 +356,7 @@ public:
                           =ISO_EXTENSION_NONE,
                           uint16_t i_fuzz=20);
 
-    /*!
+    /**
       Read the Super block of an ISO 9660 image but determine framesize
       and datastart and a possible additional offset. Generally here we are
       not reading an ISO 9660 image but a CD-Image which contains an ISO 9660
@@ -369,7 +369,7 @@ public:
                            =ISO_EXTENSION_NONE,
                            uint16_t i_fuzz=20);
 
-    /*! Read psz_path (a directory) and return a list of iso9660_stat_t
+    /** Read psz_path (a directory) and return a list of iso9660_stat_t
       pointers for the files inside that directory. The caller must free
       the returned result.
     */
@@ -394,7 +394,7 @@ public:
       }
     }
 
-    /*!
+    /**
       Seek to a position and then read n bytes. Size read is returned.
     */
     long int
@@ -403,7 +403,7 @@ public:
       return iso9660_iso_seek_read (p_iso9660, ptr, start, i_size);
     }
 
-    /*!
+    /**
       Return file status for pathname. NULL is returned on error.
       Caller must release returned object using delete when done.
     */

--- a/include/cdio++/read.hpp
+++ b/include/cdio++/read.hpp
@@ -21,39 +21,39 @@
  *  should not be #included directly.
  */
 
-/*!
+/**
   Reposition read offset
   Similar to (if not the same as) libc's lseek()
-  
+
   @param offset amount to seek
-  @param whence  like corresponding parameter in libc's lseek, e.g. 
+  @param whence  like corresponding parameter in libc's lseek, e.g.
   SEEK_SET or SEEK_END.
-  @return (off_t) -1 on error. 
+  @return (off_t) -1 on error.
 */
 
-off_t lseek(off_t offset, int whence) 
+off_t lseek(off_t offset, int whence)
 {
   return cdio_lseek(p_cdio, offset, whence);
 }
 
-/*!
+/**
   Reads into buf the next size bytes.
   Similar to (if not the same as) libc's read()
-  
+
   @param p_buf place to read data into. The caller should make sure
   this location can store at least i_size bytes.
   @param i_size number of bytes to read
-  
-  @return (ssize_t) -1 on error. 
+
+  @return (ssize_t) -1 on error.
 */
-ssize_t read(void *p_buf, size_t i_size) 
+ssize_t read(void *p_buf, size_t i_size)
 {
   return cdio_read(p_cdio, p_buf, i_size);
 }
 
-/*!
+/**
   Reads a number of sectors (AKA blocks).
-  
+
   @param p_buf place to read data into. The caller should make sure
   this location is large enough. See below for size information.
   @param read_mode the kind of "mode" to use in reading.
@@ -64,9 +64,9 @@ ssize_t read(void *p_buf, size_t i_size)
     *p_buf should hold at least CDIO_FRAMESIZE_RAW * i_blocks bytes.
 
   If read_mode is CDIO_MODE_DATA,
-    *p_buf should hold at least i_blocks times either ISO_BLOCKSIZE, 
-    M1RAW_SECTOR_SIZE or M2F2_SECTOR_SIZE depending on the kind of 
-    sector getting read. If you don't know whether you have a Mode 1/2, 
+    *p_buf should hold at least i_blocks times either ISO_BLOCKSIZE,
+    M1RAW_SECTOR_SIZE or M2F2_SECTOR_SIZE depending on the kind of
+    sector getting read. If you don't know whether you have a Mode 1/2,
     Form 1/ Form 2/Formless sector best to reserve space for the maximum
     which is M2RAW_SECTOR_SIZE.
 
@@ -79,7 +79,7 @@ ssize_t read(void *p_buf, size_t i_size)
   A DriverOpException is raised on error.
 */
 
-void readSectors(void *p_buf, lsn_t i_lsn, cdio_read_mode_t read_mode, 
+void readSectors(void *p_buf, lsn_t i_lsn, cdio_read_mode_t read_mode,
 		 uint32_t i_blocks=1)
 {
   driver_return_code_t drc = cdio_read_sectors(p_cdio, p_buf, i_lsn, read_mode,
@@ -87,33 +87,33 @@ void readSectors(void *p_buf, lsn_t i_lsn, cdio_read_mode_t read_mode,
   possible_throw_device_exception(drc);
 }
 
-/*!
+/**
   Reads a number of data sectors (AKA blocks).
-  
+
   @param p_buf place to read data into. The caller should make sure
   this location is large enough. See below for size information.
 
-  *p_buf should hold at least i_blocks times either ISO_BLOCKSIZE, 
-  M1RAW_SECTOR_SIZE or M2F2_SECTOR_SIZE depending on the kind of 
-  sector getting read. If you don't know whether you have a Mode 1/2, 
+  *p_buf should hold at least i_blocks times either ISO_BLOCKSIZE,
+  M1RAW_SECTOR_SIZE or M2F2_SECTOR_SIZE depending on the kind of
+  sector getting read. If you don't know whether you have a Mode 1/2,
   Form 1/ Form 2/Formless sector best to reserve space for the maximum
   which is M2RAW_SECTOR_SIZE.
 
   @param i_lsn sector to read
 
-  @param i_blocksize size of block. Should be either CDIO_CD_FRAMESIZE, 
+  @param i_blocksize size of block. Should be either CDIO_CD_FRAMESIZE,
   M2RAW_SECTOR_SIZE, or M2F2_SECTOR_SIZE. See comment above under p_buf.
 
   @param i_blocks number of sectors to read
 
   A DriverOpException is raised on error.
-  
+
 */
 
-void readDataBlocks(void *p_buf, lsn_t i_lsn, uint16_t i_blocksize, 
-		    uint32_t i_blocks=1) 
+void readDataBlocks(void *p_buf, lsn_t i_lsn, uint16_t i_blocksize,
+		    uint32_t i_blocks=1)
 {
-  driver_return_code_t drc = cdio_read_data_sectors (p_cdio, p_buf, i_lsn, 
+  driver_return_code_t drc = cdio_read_data_sectors (p_cdio, p_buf, i_lsn,
 						     i_blocksize, i_blocks);
   possible_throw_device_exception(drc);
 }

--- a/include/cdio++/track.hpp
+++ b/include/cdio++/track.hpp
@@ -22,7 +22,7 @@
  *  should not be #included directly.
  */
 
-/*!  
+/**
   Return an opaque CdIo_t pointer for the given track object.
 */
 CdIo_t *getCdIo()
@@ -30,7 +30,7 @@ CdIo_t *getCdIo()
   return p_cdio;
 }
 
-/*! Return number of channels in track: 2 or 4; -2 if not
+/** Return number of channels in track: 2 or 4; -2 if not
   implemented or -1 for error.
   Not meaningful if track is not an audio track.
 */
@@ -39,54 +39,54 @@ int getChannels()
   return cdio_get_track_channels(p_cdio, i_track);
 }
 
-/*! Return copy protection status on a track. Is this meaningful
+/** Return copy protection status on a track. Is this meaningful
   if not an audio track?
 */
-track_flag_t getCopyPermit() 
+track_flag_t getCopyPermit()
 {
   return cdio_get_track_copy_permit(p_cdio, i_track);
 }
 
-/*!  
-  Get the format (audio, mode2, mode1) of track. 
+/**
+  Get the format (audio, mode2, mode1) of track.
 */
 track_format_t getFormat()
 {
   return cdio_get_track_format(p_cdio, i_track);
 }
 
-/*!
+/**
   Return true if we have XA data (green, mode2 form1) or
   XA data (green, mode2 form2). That is track begins:
   sync - header - subheader
   12     4      -  8
-  
+
   FIXME: there's gotta be a better design for this and get_track_format?
 */
-bool getGreen() 
+bool getGreen()
 {
   return cdio_get_track_green(p_cdio, i_track);
 }
 
-/*!  
+/**
   Return the ending LSN. CDIO_INVALID_LSN is returned on error.
 */
-lsn_t getLastLsn() 
+lsn_t getLastLsn()
 {
   return cdio_get_track_last_lsn(p_cdio, i_track);
 }
 
-/*!  
-  Get the starting LBA. 
+/**
+  Get the starting LBA.
 
   @return the starting LBA or CDIO_INVALID_LBA on error.
 */
-lba_t getLba() 
+lba_t getLba()
 {
   return cdio_get_track_lba(p_cdio, i_track);
 }
 
-/*!  
+/**
   @return the starting LSN or CDIO_INVALID_LSN on error.
 */
 lsn_t getLsn()
@@ -95,9 +95,9 @@ lsn_t getLsn()
 }
 
 
-/*!  
+/**
   Return the starting MSF (minutes/secs/frames) for track number
-  i_track in p_cdio. 
+  i_track in p_cdio.
 
   @return true if things worked or false if there is no track entry.
 */
@@ -106,7 +106,7 @@ bool getMsf(/*out*/ msf_t &msf)
   return cdio_get_track_msf(p_cdio, i_track,/*out*/ &msf);
 }
 
-/*!  
+/**
   Return the track number of the track object.
 */
 track_t getTrackNum()
@@ -114,7 +114,7 @@ track_t getTrackNum()
   return i_track;
 }
 
-/*! Get linear preemphasis status on an audio track 
+/** Get linear preemphasis status on an audio track
   This is not meaningful if not an audio track?
 */
 track_flag_t getPreemphasis()
@@ -122,15 +122,13 @@ track_flag_t getPreemphasis()
   return cdio_get_track_preemphasis(p_cdio, i_track);
 }
 
-/*!  
+/**
   Get the number of sectors between this track an the next.  This
   includes any pregap sectors before the start of the next track.
-  
+
   @return the number of sectors or 0 if there is an error.
 */
-unsigned int getSecCount() 
+unsigned int getSecCount()
 {
   return cdio_get_track_sec_count(p_cdio, i_track);
 }
-
-

--- a/include/cdio/audio.h
+++ b/include/cdio/audio.h
@@ -30,7 +30,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-  /*! This struct is used by the cdio_audio_read_subchannel */
+  /** This struct is used by the cdio_audio_read_subchannel */
   typedef struct cdio_subchannel_s
   {
     uint8_t format;
@@ -43,14 +43,14 @@ extern "C" {
     msf_t   rel_addr;
   } cdio_subchannel_t;
 
-  /*! This struct is used by cdio_audio_get_volume and cdio_audio_set_volume */
+  /** This struct is used by cdio_audio_get_volume and cdio_audio_set_volume */
   typedef struct cdio_audio_volume_s
   {
     uint8_t level[4];
   } cdio_audio_volume_t;
 
 
-  /*! This struct is used by the CDROMPLAYTRKIND ioctl */
+  /** This struct is used by the CDROMPLAYTRKIND ioctl */
   typedef struct cdio_track_index_s
   {
     uint8_t	i_start_track;	/**< start track */
@@ -59,7 +59,7 @@ extern "C" {
     uint8_t	i_end_index;	/**< end index */
   } cdio_track_index_t;
 
-  /*!
+  /**
     Get volume of an audio CD.
 
     @param p_cdio the CD object to be acted upon.
@@ -72,19 +72,19 @@ extern "C" {
   driver_return_code_t cdio_audio_get_volume (CdIo_t *p_cdio,  /*out*/
 					      cdio_audio_volume_t *p_volume);
 
-  /*!
+  /**
     Return the number of seconds (discarding frame portion) of an MSF
   */
   uint32_t cdio_audio_get_msf_seconds(msf_t *p_msf);
 
-  /*!
+  /**
     Pause playing CD through analog output
 
     @param p_cdio the CD object to be acted upon.
   */
   driver_return_code_t cdio_audio_pause (CdIo_t *p_cdio);
 
-  /*!
+  /**
     Playing CD through analog output at the given MSF.
 
     @param p_cdio the CD object to be acted upon.
@@ -95,7 +95,7 @@ extern "C" {
 					    /*in*/msf_t *p_start_msf,
 					    /*in*/ msf_t *p_end_msf);
 
-  /*!
+  /**
     Playing CD through analog output at the desired track and index
 
     @param p_cdio the CD object to be acted upon.
@@ -104,7 +104,7 @@ extern "C" {
   driver_return_code_t cdio_audio_play_track_index
   ( CdIo_t *p_cdio,  cdio_track_index_t *p_track_index);
 
-  /*!
+  /**
     Get subchannel information.
 
     @param p_cdio the CD object to be acted upon.
@@ -113,7 +113,7 @@ extern "C" {
   driver_return_code_t cdio_audio_read_subchannel (CdIo_t *p_cdio,
 						   /*out*/ cdio_subchannel_t *p_subchannel);
 
-  /*!
+  /**
     Resume playing an audio CD.
 
     @param p_cdio the CD object to be acted upon.
@@ -121,7 +121,7 @@ extern "C" {
   */
   driver_return_code_t cdio_audio_resume (CdIo_t *p_cdio);
 
-  /*!
+  /**
     Set volume of an audio CD.
 
     @param p_cdio the CD object to be acted upon.
@@ -131,7 +131,7 @@ extern "C" {
   driver_return_code_t cdio_audio_set_volume (CdIo_t *p_cdio, /*out*/
 					      cdio_audio_volume_t *p_volume);
 
-  /*!
+  /**
     Stop playing an audio CD.
 
     @param p_cdio the CD object to be acted upon.

--- a/include/cdio/cd_types.h
+++ b/include/cdio/cd_types.h
@@ -124,7 +124,7 @@ extern "C" {
 #define CDIO_FS_MATCH_ALL            (cdio_fs_anal_t) (~CDIO_FS_MASK)
 
 
-/*!
+/**
   \brief The type used to return analysis information from
   cdio_guess_cd_type.
 

--- a/include/cdio/cdtext.h
+++ b/include/cdio/cdtext.h
@@ -17,7 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/*!
+/**
  * \file cdtext.h
  *
  * \brief The top-level header for CD-Text information. Applications
@@ -37,7 +37,7 @@ extern "C" {
 #define MIN_CDTEXT_FIELD          0
 #define MAX_CDTEXT_FIELDS         10
 
-/*! \typedef enum cdtext_field_t
+/** \typedef enum cdtext_field_t
 
   \brief Enumeration of CD-TEXT text fields.
 */
@@ -55,7 +55,7 @@ typedef enum {
   CDTEXT_FIELD_INVALID        =  MAX_CDTEXT_FIELDS /**< INVALID FIELD*/
 } cdtext_field_t;
 
-/*! \typedef enum cdtext_genre_t
+/** \typedef enum cdtext_genre_t
 
   \brief Enumeration of possible genre codes.
 */
@@ -91,7 +91,7 @@ typedef enum {
   CDTEXT_GENRE_WORLD_MUSIC    = 28    /**< World Music */
 } cdtext_genre_t;
 
-/*! \typedef typedef enum cdtext_lang_t
+/** \typedef typedef enum cdtext_lang_t
 
     \brief Enumeration of possible CD-TEXT languages.
 
@@ -210,24 +210,24 @@ typedef enum {
 
 } cdtext_lang_t;
 
-/*!
+/**
   \typedef struct cdtext_s cdtext_t
 
   \brief Opaque type for CD-Text.
 */
 typedef struct cdtext_s cdtext_t;
 
-/*!
+/**
   Return string representation of the given genre code.
 */
 const char *cdtext_genre2str (cdtext_genre_t i);
 
-/*!
+/**
   Return string representation of the given language code.
 */
 const char *cdtext_lang2str (cdtext_lang_t i);
 
-/*!
+/**
   Return the language code of a given language string representation.
   This is the inverse of cdtext_lang2str().
 
@@ -239,12 +239,12 @@ const char *cdtext_lang2str (cdtext_lang_t i);
 */
 cdtext_lang_t cdtext_str2lang (const char *lang);
 
-/*!
+/**
   Return string representation of given field type.
 */
 const char *cdtext_field2str (cdtext_field_t i);
 
-/*!
+/**
   Initialize a new \p cdtext_t structure.
 
   When the structure is no longer needed, release the
@@ -252,7 +252,7 @@ const char *cdtext_field2str (cdtext_field_t i);
 */
 cdtext_t *cdtext_init (void);
 
-/*!
+/**
   Fill a cdtext_t object with text pack bytes as they were handed out by the
   CD drive, but without the 4-byte header which the drive prepended.
 
@@ -286,14 +286,14 @@ cdtext_t *cdtext_init (void);
 */
 int cdtext_data_init(cdtext_t *p_cdtext, uint8_t *wdata, size_t i_data);
 
-/*!
+/**
   Free memory associated with the given \p cdtext_t object.
 
   @param p_cdtext the CD-TEXT object
 */
 void cdtext_destroy (cdtext_t *p_cdtext);
 
-/*!
+/**
   Returns a copy of the return value of cdtext_get_const or NULL.
 
   Must be freed using cdio_free() when done.
@@ -301,7 +301,7 @@ void cdtext_destroy (cdtext_t *p_cdtext);
 */
 char *cdtext_get (const cdtext_t *p_cdtext, cdtext_field_t key, track_t track);
 
-/*!
+/**
   Returns value of the given field.
 
   NULL is returned if key is CDTEXT_INVALID or the field is not set.
@@ -314,35 +314,35 @@ char *cdtext_get (const cdtext_t *p_cdtext, cdtext_field_t key, track_t track);
 const char *cdtext_get_const (const cdtext_t *p_cdtext, cdtext_field_t field,
                               track_t track);
 
-/*!
+/**
   Returns the discs genre code.
 
   @param p_cdtext the CD-TEXT object
 */
 cdtext_genre_t cdtext_get_genre (const cdtext_t *p_cdtext);
 
-/*!
+/**
   Returns the currently active language.
 
   @param p_cdtext the CD-TEXT object
 */
 cdtext_lang_t cdtext_get_language (const cdtext_t *p_cdtext);
 
-/*!
+/**
   Returns the first track number.
 
   @param p_cdtext the CD-TEXT object
 */
 track_t cdtext_get_first_track(const cdtext_t *p_cdtext);
 
-/*!
+/**
   Returns the last track number.
 
   @param p_cdtext the CD-TEXT object
 */
 track_t cdtext_get_last_track(const cdtext_t *p_cdtext);
 
-/*!
+/**
   Try to select the given language.
 
   @param p_cdtext the CD-TEXT object
@@ -352,7 +352,7 @@ track_t cdtext_get_last_track(const cdtext_t *p_cdtext);
 */
 bool cdtext_select_language(cdtext_t *p_cdtext, cdtext_lang_t language);
 
-/*!
+/**
 
   @deprecated Use cdtext_list_languages_v2()
 
@@ -371,7 +371,7 @@ bool cdtext_select_language(cdtext_t *p_cdtext, cdtext_lang_t language);
 */
 cdtext_lang_t *cdtext_list_languages (const cdtext_t *p_cdtext);
 
-/*!
+/**
   Returns an array of available languages or NULL.
   The index of an array element may be used to select the corresponding
   language block by call cdtext_set_language_index().
@@ -394,7 +394,7 @@ cdtext_lang_t *cdtext_list_languages (const cdtext_t *p_cdtext);
 */
 cdtext_lang_t *cdtext_list_languages_v2(cdtext_t *p_cdtext);
 
-/*!
+/**
   Select the given language by block index. See cdtext_list_languages_v2().
   If the index is bad, or no language block with that index was read:
   select the default language at index 0 and return false.
@@ -407,7 +407,7 @@ cdtext_lang_t *cdtext_list_languages_v2(cdtext_t *p_cdtext);
 bool
 cdtext_set_language_index(cdtext_t *p_cdtext, int idx);
 
-/*!
+/**
   Sets the given field at the given track to the given value.
 
   Recodes to UTF-8 if charset is not \p NULL.

--- a/include/cdio/device.h
+++ b/include/cdio/device.h
@@ -1,6 +1,7 @@
 /* -*- c -*-
 
-    Copyright (C) 2005-2006, 2008-2013, 2025 Rocky Bernstein <rocky@gnu.org>
+    Copyright (C) 2005-2006, 2008-2013, 2025-2026 Rocky Bernstein
+   <rocky@gnu.org>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -29,938 +30,928 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#include <cdio/types.h>
 #include <cdio/cdio.h>
+#include <cdio/types.h>
 
-  /** The type of an drive capability bit mask. See below for values*/
-  typedef uint32_t cdio_drive_read_cap_t;
-  typedef uint32_t cdio_drive_write_cap_t;
-  typedef uint32_t cdio_drive_misc_cap_t;
+/** The type of an drive capability bit mask. See below for values*/
+typedef uint32_t cdio_drive_read_cap_t;
+typedef uint32_t cdio_drive_write_cap_t;
+typedef uint32_t cdio_drive_misc_cap_t;
 
-  /**
-    \brief Drive capability bits returned by cdio_get_drive_cap()
-    NOTE: Setting a bit here means the presence of a capability.
-  */
+/**
+  \brief Drive capability bits returned by cdio_get_drive_cap()
+  NOTE: Setting a bit here means the presence of a capability.
+*/
 
-  /** Miscellaneous capabilities. */
-  typedef enum {
-    CDIO_DRIVE_CAP_ERROR             = 0x40000, /**< Error */
-    CDIO_DRIVE_CAP_UNKNOWN           = 0x80000, /**< Dunno. It can be on if we
-                                                have only partial information
-                                                or are not completely certain
-                                                */
-    CDIO_DRIVE_CAP_MISC_CLOSE_TRAY   = 0x00001, /**< caddy systems can't
-                                                     close... */
-    CDIO_DRIVE_CAP_MISC_EJECT        = 0x00002, /**< but can eject.  */
-    CDIO_DRIVE_CAP_MISC_LOCK         = 0x00004, /**< disable manual eject */
-    CDIO_DRIVE_CAP_MISC_SELECT_SPEED = 0x00008, /**< programmable speed */
-    CDIO_DRIVE_CAP_MISC_SELECT_DISC  = 0x00010, /**< select disc from
-                                                      juke-box */
-    CDIO_DRIVE_CAP_MISC_MULTI_SESSION= 0x00020, /**< read sessions>1 */
-    CDIO_DRIVE_CAP_MISC_MEDIA_CHANGED= 0x00080, /**< media changed */
-    CDIO_DRIVE_CAP_MISC_RESET        = 0x00100, /**< hard reset device */
-    CDIO_DRIVE_CAP_MISC_FILE         = 0x20000 /**< drive is really a file,
+/** Miscellaneous capabilities. */
+typedef enum {
+  CDIO_DRIVE_CAP_ERROR = 0x40000,              /**< Error */
+  CDIO_DRIVE_CAP_UNKNOWN = 0x80000,            /**< Dunno. It can be on if we
+                                               have only partial information
+                                               or are not completely certain
+                                               */
+  CDIO_DRIVE_CAP_MISC_CLOSE_TRAY = 0x00001,    /**< caddy systems can't
+                                                    close... */
+  CDIO_DRIVE_CAP_MISC_EJECT = 0x00002,         /**< but can eject.  */
+  CDIO_DRIVE_CAP_MISC_LOCK = 0x00004,          /**< disable manual eject */
+  CDIO_DRIVE_CAP_MISC_SELECT_SPEED = 0x00008,  /**< programmable speed */
+  CDIO_DRIVE_CAP_MISC_SELECT_DISC = 0x00010,   /**< select disc from
+                                                     juke-box */
+  CDIO_DRIVE_CAP_MISC_MULTI_SESSION = 0x00020, /**< read sessions>1 */
+  CDIO_DRIVE_CAP_MISC_MEDIA_CHANGED = 0x00080, /**< media changed */
+  CDIO_DRIVE_CAP_MISC_RESET = 0x00100,         /**< hard reset device */
+  CDIO_DRIVE_CAP_MISC_FILE = 0x20000           /**< drive is really a file,
                                                   i.e a CD file image */
-  } cdio_drive_cap_misc_t;
+} cdio_drive_cap_misc_t;
 
-  /** Reading masks.. */
-  typedef enum {
-    CDIO_DRIVE_CAP_READ_AUDIO        = 0x00001, /**< drive can play CD audio */
-    CDIO_DRIVE_CAP_READ_CD_DA        = 0x00002, /**< drive can read CD-DA */
-    CDIO_DRIVE_CAP_READ_CD_G         = 0x00004, /**< drive can read CD+G  */
-    CDIO_DRIVE_CAP_READ_CD_R         = 0x00008, /**< drive can read CD-R  */
-    CDIO_DRIVE_CAP_READ_CD_RW        = 0x00010, /**< drive can read CD-RW */
-    CDIO_DRIVE_CAP_READ_DVD_R        = 0x00020, /**< drive can read DVD-R */
-    CDIO_DRIVE_CAP_READ_DVD_PR       = 0x00040, /**< drive can read DVD+R */
-    CDIO_DRIVE_CAP_READ_DVD_RAM      = 0x00080, /**< drive can read DVD-RAM */
-    CDIO_DRIVE_CAP_READ_DVD_ROM      = 0x00100, /**< drive can read DVD-ROM */
-    CDIO_DRIVE_CAP_READ_DVD_RW       = 0x00200, /**< drive can read DVD-RW  */
-    CDIO_DRIVE_CAP_READ_DVD_RPW      = 0x00400, /**< drive can read DVD+RW  */
-    CDIO_DRIVE_CAP_READ_C2_ERRS      = 0x00800, /**< has C2 error correction */
-    CDIO_DRIVE_CAP_READ_MODE2_FORM1  = 0x01000, /**< can read mode 2 form 1 */
-    CDIO_DRIVE_CAP_READ_MODE2_FORM2  = 0x02000, /**< can read mode 2 form 2 */
-    CDIO_DRIVE_CAP_READ_MCN          = 0x04000, /**< can read MCN      */
-    CDIO_DRIVE_CAP_READ_ISRC         = 0x08000 /**< can read ISRC     */
-  } cdio_drive_cap_read_t;
+/** Reading masks.. */
+typedef enum {
+  CDIO_DRIVE_CAP_READ_AUDIO = 0x00001,       /**< drive can play CD audio */
+  CDIO_DRIVE_CAP_READ_CD_DA = 0x00002,       /**< drive can read CD-DA */
+  CDIO_DRIVE_CAP_READ_CD_G = 0x00004,        /**< drive can read CD+G  */
+  CDIO_DRIVE_CAP_READ_CD_R = 0x00008,        /**< drive can read CD-R  */
+  CDIO_DRIVE_CAP_READ_CD_RW = 0x00010,       /**< drive can read CD-RW */
+  CDIO_DRIVE_CAP_READ_DVD_R = 0x00020,       /**< drive can read DVD-R */
+  CDIO_DRIVE_CAP_READ_DVD_PR = 0x00040,      /**< drive can read DVD+R */
+  CDIO_DRIVE_CAP_READ_DVD_RAM = 0x00080,     /**< drive can read DVD-RAM */
+  CDIO_DRIVE_CAP_READ_DVD_ROM = 0x00100,     /**< drive can read DVD-ROM */
+  CDIO_DRIVE_CAP_READ_DVD_RW = 0x00200,      /**< drive can read DVD-RW  */
+  CDIO_DRIVE_CAP_READ_DVD_RPW = 0x00400,     /**< drive can read DVD+RW  */
+  CDIO_DRIVE_CAP_READ_C2_ERRS = 0x00800,     /**< has C2 error correction */
+  CDIO_DRIVE_CAP_READ_MODE2_FORM1 = 0x01000, /**< can read mode 2 form 1 */
+  CDIO_DRIVE_CAP_READ_MODE2_FORM2 = 0x02000, /**< can read mode 2 form 2 */
+  CDIO_DRIVE_CAP_READ_MCN = 0x04000,         /**< can read MCN      */
+  CDIO_DRIVE_CAP_READ_ISRC = 0x08000         /**< can read ISRC     */
+} cdio_drive_cap_read_t;
 
-  /** Writing masks.. */
-  typedef enum {
-    CDIO_DRIVE_CAP_WRITE_CD_R        = 0x00001, /**< drive can write CD-R */
-    CDIO_DRIVE_CAP_WRITE_CD_RW       = 0x00002, /**< drive can write CD-RW */
-    CDIO_DRIVE_CAP_WRITE_DVD_R       = 0x00004, /**< drive can write DVD-R */
-    CDIO_DRIVE_CAP_WRITE_DVD_PR      = 0x00008, /**< drive can write DVD+R */
-    CDIO_DRIVE_CAP_WRITE_DVD_RAM     = 0x00010, /**< drive can write DVD-RAM */
-    CDIO_DRIVE_CAP_WRITE_DVD_RW      = 0x00020, /**< drive can write DVD-RW */
-    CDIO_DRIVE_CAP_WRITE_DVD_RPW     = 0x00040, /**< drive can write DVD+RW */
-    CDIO_DRIVE_CAP_WRITE_MT_RAINIER  = 0x00080, /**< Mount Rainier           */
-    CDIO_DRIVE_CAP_WRITE_BURN_PROOF  = 0x00100, /**< burn proof */
-    CDIO_DRIVE_CAP_WRITE_CD =
-    (CDIO_DRIVE_CAP_WRITE_CD_R | CDIO_DRIVE_CAP_WRITE_CD_RW),
-    /**< Has some sort of CD writer ability */
+/** Writing masks.. */
+typedef enum {
+  CDIO_DRIVE_CAP_WRITE_CD_R = 0x00001,       /**< drive can write CD-R */
+  CDIO_DRIVE_CAP_WRITE_CD_RW = 0x00002,      /**< drive can write CD-RW */
+  CDIO_DRIVE_CAP_WRITE_DVD_R = 0x00004,      /**< drive can write DVD-R */
+  CDIO_DRIVE_CAP_WRITE_DVD_PR = 0x00008,     /**< drive can write DVD+R */
+  CDIO_DRIVE_CAP_WRITE_DVD_RAM = 0x00010,    /**< drive can write DVD-RAM */
+  CDIO_DRIVE_CAP_WRITE_DVD_RW = 0x00020,     /**< drive can write DVD-RW */
+  CDIO_DRIVE_CAP_WRITE_DVD_RPW = 0x00040,    /**< drive can write DVD+RW */
+  CDIO_DRIVE_CAP_WRITE_MT_RAINIER = 0x00080, /**< Mount Rainier           */
+  CDIO_DRIVE_CAP_WRITE_BURN_PROOF = 0x00100, /**< burn proof */
+  CDIO_DRIVE_CAP_WRITE_CD =
+      (CDIO_DRIVE_CAP_WRITE_CD_R | CDIO_DRIVE_CAP_WRITE_CD_RW),
+  /**< Has some sort of CD writer ability */
 
-    CDIO_DRIVE_CAP_WRITE_DVD =
-    (CDIO_DRIVE_CAP_WRITE_DVD_R | CDIO_DRIVE_CAP_WRITE_DVD_PR
-     | CDIO_DRIVE_CAP_WRITE_DVD_RAM | CDIO_DRIVE_CAP_WRITE_DVD_RW
-     | CDIO_DRIVE_CAP_WRITE_DVD_RPW ),
-    /**< Has some sort of DVD writer ability */
+  CDIO_DRIVE_CAP_WRITE_DVD =
+      (CDIO_DRIVE_CAP_WRITE_DVD_R | CDIO_DRIVE_CAP_WRITE_DVD_PR |
+       CDIO_DRIVE_CAP_WRITE_DVD_RAM | CDIO_DRIVE_CAP_WRITE_DVD_RW |
+       CDIO_DRIVE_CAP_WRITE_DVD_RPW),
+  /**< Has some sort of DVD writer ability */
 
-    CDIO_DRIVE_CAP_WRITE =
-    (CDIO_DRIVE_CAP_WRITE_CD | CDIO_DRIVE_CAP_WRITE_DVD)
-    /**< Has some sort of DVD or CD writing ability */
-  } cdio_drive_cap_write_t;
+  CDIO_DRIVE_CAP_WRITE = (CDIO_DRIVE_CAP_WRITE_CD | CDIO_DRIVE_CAP_WRITE_DVD)
+  /**< Has some sort of DVD or CD writing ability */
+} cdio_drive_cap_write_t;
 
 /** Size of fields returned by an \p INQUIRY command */
-  typedef enum {
-    CDIO_MMC_HW_VENDOR_LEN   =  8, /**< length of vendor field */
-    CDIO_MMC_HW_MODEL_LEN    = 16, /**< length of model field */
-    CDIO_MMC_HW_REVISION_LEN =  4  /**< length of revision field */
-  } cdio_mmc_hw_len_t;
+typedef enum {
+  CDIO_MMC_HW_VENDOR_LEN = 8,  /**< length of vendor field */
+  CDIO_MMC_HW_MODEL_LEN = 16,  /**< length of model field */
+  CDIO_MMC_HW_REVISION_LEN = 4 /**< length of revision field */
+} cdio_mmc_hw_len_t;
 
+/** \brief Structure to return CD vendor, model, and revision-level
+    strings obtained via the \p INQUIRY command  */
+typedef struct cdio_hwinfo {
+  char psz_vendor[CDIO_MMC_HW_VENDOR_LEN + 1];
+  char psz_model[CDIO_MMC_HW_MODEL_LEN + 1];
+  char psz_revision[CDIO_MMC_HW_REVISION_LEN + 1];
+} cdio_hwinfo_t;
 
-  /** \brief Structure to return CD vendor, model, and revision-level
-      strings obtained via the \p INQUIRY command  */
-  typedef struct cdio_hwinfo
-  {
-    char psz_vendor  [CDIO_MMC_HW_VENDOR_LEN+1];
-    char psz_model   [CDIO_MMC_HW_MODEL_LEN+1];
-    char psz_revision[CDIO_MMC_HW_REVISION_LEN+1];
-  } cdio_hwinfo_t;
+/** Flags specifying the category of device to open or is opened. */
+typedef enum {
+  CDIO_SRC_IS_DISK_IMAGE_MASK = 0x0001, /**< Read source is a CD image. */
+  CDIO_SRC_IS_DEVICE_MASK = 0x0002,     /**< Read source is a CD device. */
+  CDIO_SRC_IS_SCSI_MASK = 0x0004,       /**< Read source SCSI device. */
+  CDIO_SRC_IS_NATIVE_MASK = 0x0008
+} cdio_src_category_mask_t;
 
+/**
+ * The driver_id_t enumerations may be used to tag a specific driver
+ * that is opened or is desired to be opened. Note that this is
+ * different than what is available on a given host.
+ *
+ * Order should not be changed lightly because it breaks the ABI.
+ * One is not supposed to iterate over the values, but iterate over the
+ * cdio_drivers and cdio_device_drivers arrays.
+ *
+ * NOTE: IF YOU MODIFY ENUM MAKE SURE INITIALIZATION IN CDIO.C AGREES.
+ *
+ */
+typedef enum {
+  DRIVER_UNKNOWN, /**< Used as input when we don't care what kind
+                       of driver to use. */
+  DRIVER_AIX,     /**< AIX driver */
+  DRIVER_FREEBSD, /**< FreeBSD driver - includes CAM and ioctl access */
+  DRIVER_NETBSD,  /**< NetBSD Driver. */
+  DRIVER_LINUX,   /**< GNU/Linux Driver */
+  DRIVER_SOLARIS, /**< Sun Solaris Driver */
+  DRIVER_OSX,     /**< Apple OSX (or MacOS) Driver */
+  DRIVER_WIN32,   /**< Microsoft Windows Driver. Includes ASPI and
+                       ioctl access. */
+  DRIVER_CDRDAO,  /**< cdrdao format CD image. This is listed
+                       before BIN/CUE, to make the code prefer cdrdao
+                       over BIN/CUE when both exist. */
+  DRIVER_BINCUE,  /**< CDRWIN BIN/CUE format CD image. This is
+                       listed before NRG, to make the code prefer
+                       BIN/CUE over NRG when both exist. */
+  DRIVER_NRG,     /**< Nero NRG format CD image. */
+  DRIVER_DEVICE   /**< Is really a set of the above; should come last */
+} driver_id_t;
 
-  /** Flags specifying the category of device to open or is opened. */
-  typedef enum {
-    CDIO_SRC_IS_DISK_IMAGE_MASK = 0x0001, /**< Read source is a CD image. */
-    CDIO_SRC_IS_DEVICE_MASK     = 0x0002, /**< Read source is a CD device. */
-    CDIO_SRC_IS_SCSI_MASK       = 0x0004, /**< Read source SCSI device. */
-    CDIO_SRC_IS_NATIVE_MASK     = 0x0008
-  } cdio_src_category_mask_t;
+/**
+    A null-terminated (that is DRIVER_UNKNOWN-terminated) ordered (in
+    order of preference) array of drivers.
+*/
+extern const driver_id_t cdio_drivers[];
 
+/**
+   A null-terminated (that is DRIVER_UNKNOWN-terminated) ordered (in
+   order of preference) array of device drivers.
+*/
+extern const driver_id_t cdio_device_drivers[];
 
-  /**
-   * The driver_id_t enumerations may be used to tag a specific driver
-   * that is opened or is desired to be opened. Note that this is
-   * different than what is available on a given host.
-   *
-   * Order should not be changed lightly because it breaks the ABI.
-   * One is not supposed to iterate over the values, but iterate over the
-   * cdio_drivers and cdio_device_drivers arrays.
-   *
-   * NOTE: IF YOU MODIFY ENUM MAKE SURE INITIALIZATION IN CDIO.C AGREES.
-   *
-   */
-  typedef enum  {
-    DRIVER_UNKNOWN, /**< Used as input when we don't care what kind
-                         of driver to use. */
-    DRIVER_AIX,     /**< AIX driver */
-    DRIVER_FREEBSD, /**< FreeBSD driver - includes CAM and ioctl access */
-    DRIVER_NETBSD,  /**< NetBSD Driver. */
-    DRIVER_LINUX,   /**< GNU/Linux Driver */
-    DRIVER_SOLARIS, /**< Sun Solaris Driver */
-    DRIVER_OSX,     /**< Apple OSX (or MacOS) Driver */
-    DRIVER_WIN32,   /**< Microsoft Windows Driver. Includes ASPI and
-                         ioctl access. */
-    DRIVER_CDRDAO,  /**< cdrdao format CD image. This is listed
-                         before BIN/CUE, to make the code prefer cdrdao
-                         over BIN/CUE when both exist. */
-    DRIVER_BINCUE,  /**< CDRWIN BIN/CUE format CD image. This is
-                         listed before NRG, to make the code prefer
-                         BIN/CUE over NRG when both exist. */
-    DRIVER_NRG,     /**< Nero NRG format CD image. */
-    DRIVER_DEVICE   /**< Is really a set of the above; should come last */
-  } driver_id_t;
+/**
+    There will generally be only one hardware for a given
+    build/platform from the list above. You can use the variable
+    below to determine which you've got. If the build doesn't make an
+    hardware driver, then the value will be DRIVER_UNKNOWN.
+*/
+extern const driver_id_t cdio_os_driver;
 
-  /**
-      A null-terminated (that is DRIVER_UNKNOWN-terminated) ordered (in
-      order of preference) array of drivers.
-  */
-  extern const driver_id_t cdio_drivers[];
+/**
+    The following are status codes for completion of a given cdio
+    operation. By design 0 is successful completion and -1 is error
+    completion. This is compatible with ioctl so those routines that
+    call ioctl can just pass the value the get back (cast as this
+    enum). Also, by using negative numbers for errors, the
+    enumeration values below can be used in places where a positive
+    value is expected when things complete successfully. For example,
+    get_blocksize returns the blocksize, but on error uses the error
+    codes below. So note that this enumeration is often cast to an
+    integer.  C seems to tolerate this.
+*/
+typedef enum {
+  DRIVER_OP_SUCCESS = 0,         /**< in cases where an int is
+                                  returned, like cdio_set_speed,
+                                  more the negative return codes are
+                                  for errors and the positive ones
+                                  for success. */
+  DRIVER_OP_ERROR = -1,          /**< operation returned an error */
+  DRIVER_OP_UNSUPPORTED = -2,    /**< returned when a particular driver
+                                    doesn't support a particular operation.
+                                    For example an image driver which doesn't
+                                    really "eject" a CD.
+                                 */
+  DRIVER_OP_UNINIT = -3,         /**< returned when a particular driver
+                                    hasn't been initialized or a null
+                                    pointer has been passed.
+                                 */
+  DRIVER_OP_NOT_PERMITTED = -4,  /**< Operation not permitted.
+                                    For example might be a permission
+                                    problem.
+                                 */
+  DRIVER_OP_BAD_PARAMETER = -5,  /**< Bad parameter passed  */
+  DRIVER_OP_BAD_POINTER = -6,    /**< Bad pointer to memory area  */
+  DRIVER_OP_NO_DRIVER = -7,      /**< Operation called on a driver
+                                    not available on this OS  */
+  DRIVER_OP_MMC_SENSE_DATA = -8, /**< MMC operation returned sense data,
+                                    but no other error above recorded. */
+} driver_return_code_t;
 
-  /**
-     A null-terminated (that is DRIVER_UNKNOWN-terminated) ordered (in
-     order of preference) array of device drivers.
-  */
-  extern const driver_id_t cdio_device_drivers[];
+/**
+  @brief Close media tray in CD drive if there is a routine to do so.
 
-  /**
-      There will generally be only one hardware for a given
-      build/platform from the list above. You can use the variable
-      below to determine which you've got. If the build doesn't make an
-      hardware driver, then the value will be DRIVER_UNKNOWN.
-  */
-  extern const driver_id_t cdio_os_driver;
+  @param psz_drive The name of CD-ROM to be closed. If NULL, the default
+                   device will be used.
+  @param p_driver_id The driver to be used or that was used if it was
+                     \p DRIVER_UNKNOWN or \p DRIVER_DEVICE. If this is \p NULL,
+                     the driver used will not be reported back.
+  @return DRIVER_OP_SUCCESS on success, or a negative driver_return_code_t
+          value on error.
+*/
+driver_return_code_t cdio_close_tray(const char *psz_drive,
+                                     /*in/out*/ driver_id_t *p_driver_id);
 
+/**
+  @brief Get error message string for a driver return code.
 
-  /**
-      The following are status codes for completion of a given cdio
-      operation. By design 0 is successful completion and -1 is error
-      completion. This is compatible with ioctl so those routines that
-      call ioctl can just pass the value the get back (cast as this
-      enum). Also, by using negative numbers for errors, the
-      enumeration values below can be used in places where a positive
-      value is expected when things complete successfully. For example,
-      get_blocksize returns the blocksize, but on error uses the error
-      codes below. So note that this enumeration is often cast to an
-      integer.  C seems to tolerate this.
-  */
-  typedef enum  {
-    DRIVER_OP_SUCCESS        =  0, /**< in cases where an int is
-                                    returned, like cdio_set_speed,
-                                    more the negative return codes are
-                                    for errors and the positive ones
-                                    for success. */
-    DRIVER_OP_ERROR          = -1, /**< operation returned an error */
-    DRIVER_OP_UNSUPPORTED    = -2, /**< returned when a particular driver
-                                      doesn't support a particular operation.
-                                      For example an image driver which doesn't
-                                      really "eject" a CD.
-                                   */
-    DRIVER_OP_UNINIT         = -3, /**< returned when a particular driver
-                                      hasn't been initialized or a null
-                                      pointer has been passed.
-                                   */
-    DRIVER_OP_NOT_PERMITTED  = -4, /**< Operation not permitted.
-                                      For example might be a permission
-                                      problem.
-                                   */
-    DRIVER_OP_BAD_PARAMETER  = -5, /**< Bad parameter passed  */
-    DRIVER_OP_BAD_POINTER    = -6, /**< Bad pointer to memory area  */
-    DRIVER_OP_NO_DRIVER      = -7, /**< Operation called on a driver
-                                      not available on this OS  */
-    DRIVER_OP_MMC_SENSE_DATA = -8, /**< MMC operation returned sense data,
-                                      but no other error above recorded. */
-  } driver_return_code_t;
+  @param drc The return code to be interpreted.
+  @return The string description of the return code \p drc, or a generic
+          error message if \p drc is unrecognized.
+*/
+const char *cdio_driver_errmsg(driver_return_code_t drc);
 
-  /**
-    Close media tray in CD drive if there is a routine to do so.
+/**
+  @brief Eject media from CD drive.
 
-    @param psz_drive the name of CD-ROM to be closed. If NULL, we will
-    use the default device.
+  Eject media in CD drive if there is a routine to do so.
 
-    @param p_driver_id is the driver to be used or that got used if
-    it was \p DRIVER_UNKNOWN or \p DRIVER_DEVICE; If this is \p NULL, we won't
-    report back the driver used.
-  */
-  driver_return_code_t cdio_close_tray (const char *psz_drive,
-                                        /*in/out*/ driver_id_t *p_driver_id);
+  @param p_cdio The CD object to be acted upon. If the CD is successfully
+                ejected, \p *p_cdio is freed and the pointer is set to \p NULL.
+  @return DRIVER_OP_SUCCESS on success, or a negative driver_return_code_t
+          value on error.
+*/
+driver_return_code_t cdio_eject_media(CdIo_t **p_cdio);
 
-  /**
-    @param drc the return code you want interpreted.
+/**
+  Eject media in CD drive if there is a routine to do so.
 
-    @return the string information about \p drc
-  */
-  const char *cdio_driver_errmsg(driver_return_code_t drc);
+  @param psz_drive the name of the device to be acted upon.
+  If NULL is given as the drive, we'll use the default driver device.
+*/
+driver_return_code_t cdio_eject_media_drive(const char *psz_drive);
 
-  /**
-    Eject media in CD drive if there is a routine to do so.
+/**
+  @brief Free device list returned by device enumeration functions.
+
+  @param device_list The device list returned by cdio_get_devices() or
+                     cdio_get_devices_with_cap().
+  @see cdio_get_devices()
+  @see cdio_get_devices_with_cap()
+
+*/
+void cdio_free_device_list(char *device_list[]);
+
+/**
+  @brief Get the default CD device name.
+
+  If \p p_cdio is \p NULL (a specific device driver has not been initialized),
+  find a suitable driver and return the default device for that driver.
+
+  @param p_cdio The CD object queried, or NULL to use default driver detection.
+  @return A string containing the default CD device name, or \p NULL if no
+          default device could be determined. In some situations of drivers or
+          OS's, no CD device is found if there is no media inserted, even if
+          hardware CD-ROM exists.
+*/
+char *cdio_get_default_device(const CdIo_t *p_cdio);
+
+/**
+  @brief Get the default CD device name for a specified driver.
+
+  If \p p_driver_id is \p DRIVER_UNKNOWN or \p DRIVER_DEVICE, a suitable
+  driver is found and the default device for that driver is returned.
+
+  @param p_driver_id On input, the desired driver ID or \p DRIVER_UNKNOWN.
+                     On output, the driver ID that was actually used.
+  @return A string containing the default CD device name, or \p NULL if no
+          default device could be determined.
+*/
+char *cdio_get_default_device_driver(/*in/out*/ driver_id_t *p_driver_id);
+
+/** Return an array of device names. If you want a specific
+  devices for a driver, give that device. If you want hardware
+  devices, give \p DRIVER_DEVICE and if you want all possible devices,
+  image drivers and hardware drivers give \p DRIVER_UNKNOWN.
+
+  NULL is returned if we couldn't return a list of devices.
+
+  In some situations of drivers or OS's we can't find a CD device if
+  there is no media in it and it is possible for this routine to return
+  \p NULL even though there may be a hardware CD-ROM.
+*/
+char **cdio_get_devices(driver_id_t driver_id);
+
+/**
+   Get an array of device names in search_devices that have at least
+   the capabilities listed by the capabities parameter.  If
+   search_devices is \p NULL, then we'll search all possible CD drives.
+
+   Capabilities have two parts to them, a "filesystem" part and an
+   "analysis" part.
+
+   The filesystem part is mutually exclusive. For example either the
+   filesystem is at most one of the High-Sierra, UFS, or HFS,
+   ISO9660, filesystems. Valid combinations of say HFS and ISO9660
+   are specified as a separate "filesystem".
+
+   Capabilities on the other hand are not mutually exclusive. For
+   example a filesystem may have none, either, or both of the XA or
+   Rock-Ridge extension properties.
+
+   If "b_any" is set false then every capability listed in the
+   analysis portion of capabilities (i.e. not the basic filesystem)
+   must be satisfied. If no analysis capabilities are specified,
+   that's a match.
+
+   If "b_any" is set true, then if any of the analysis capabilities
+   matches, we call that a success.
+
+   In either case, in the filesystem portion different filesystem
+   either specify 0 to match any filesystem or the specific
+   filesystem type.
+
+   To find a CD-drive of any type, use the mask CDIO_FS_MATCH_ALL.
+
+   @return the array of device names or NULL if we couldn't get a
+   default device.  It is also possible to return a non NULL but
+   after dereferencing the the value is NULL. This also means nothing
+   was found.
+*/
+char **cdio_get_devices_with_cap(/*in*/ char *ppsz_search_devices[],
+                                 cdio_fs_anal_t capabilities, bool b_any);
+
+/**
+   Like cdio_get_devices_with_cap() but we return the driver we found
+   as well. This is because often one wants to search for kind of drive
+   and then *open* it afterwards. Giving the driver back facilitates this,
+   and speeds things up for libcdio as well.
+*/
+char **cdio_get_devices_with_cap_ret(/*in*/ char *ppsz_search_devices[],
+                                     cdio_fs_anal_t capabilities, bool b_any,
+                                     /*out*/ driver_id_t *p_driver_id);
+
+/**
+   Like cdio_get_devices(), but we may change the p_driver_id if we
+   were given \p DRIVER_DEVICE or \p DRIVER_UNKNOWN. This is because often
+   one wants to get a drive name and then *open* it
+   afterwards. Giving the driver back facilitates this, and speeds
+   things up for libcdio as well.
+ */
+
+char **cdio_get_devices_ret(/*in/out*/ driver_id_t *p_driver_id);
+
+/**
+   Get the what kind of device we've got.
+
+   @param p_cdio the CD object queried
+   @param p_read_cap pointer to return read capabilities
+   @param p_write_cap pointer to return write capabilities
+   @param p_misc_cap pointer to return miscellaneous other capabilities
+
+   In some situations of drivers or OS's we can't find a CD device if
+   there is no media in it. In this situation capabilities will show up as
+   \p NULL even though there isa hardware CD-ROM.
+*/
+void cdio_get_drive_cap(const CdIo_t *p_cdio, cdio_drive_read_cap_t *p_read_cap,
+                        cdio_drive_write_cap_t *p_write_cap,
+                        cdio_drive_misc_cap_t *p_misc_cap);
+
+/**
+   Get the drive capabilities for a specified device.
+
+   Return a list of device capabilities.
+
+   In some situations of drivers or OS's we can't find a CD device if
+   there is no media in it. In this situation capabilities will show up as
+   \p NULL even though there isa hardware CD-ROM.
+*/
+void cdio_get_drive_cap_dev(const char *device,
+                            cdio_drive_read_cap_t *p_read_cap,
+                            cdio_drive_write_cap_t *p_write_cap,
+                            cdio_drive_misc_cap_t *p_misc_cap);
+
+/**
+   Get a string containing the name of the driver in use.
+
+   @param p_cdio the CD object to be acted upon.
+
+   @return a string with driver name or NULL if CdIo_t is NULL (we
+   haven't initialized a specific device.
+*/
+const char *cdio_get_driver_name(const CdIo_t *p_cdio);
+
+/**
+   Return a string name for the \p driver_id.
+*/
+const char *cdio_get_driver_name_from_id(driver_id_t driver_id);
+
+/**
+   Get the driver id.
+   if \p p_cdio is \p NULL (we haven't initialized a specific device driver),
+   then return \p DRIVER_UNKNOWN.
+
+   @param p_cdio the CD object to be acted upon.
+
+   @return the driver id..
+*/
+driver_id_t cdio_get_driver_id(const CdIo_t *p_cdio);
+
+/**
+  Get the CD-ROM hardware info via a SCSI MMC INQUIRY command.
+  False is returned if we had an error getting the information.
+*/
+bool cdio_get_hwinfo(const CdIo_t *p_cdio,
+                     /*out*/ cdio_hwinfo_t *p_hw_info);
+
+/**
+   Get the LSN of the first track of the last session of
+   on the CD.
+
+   @param p_cdio the CD object to be acted upon.
+   @param i_last_session pointer to the session number to be returned.
+*/
+driver_return_code_t cdio_get_last_session(CdIo_t *p_cdio,
+                                           /*out*/ lsn_t *i_last_session);
+
+/**
+    Find out if media has changed since the last call.
 
     @param p_cdio the CD object to be acted upon.
-    If the CD is ejected \p *p_cdio is free'd and p_cdio set to \p NULL.
-  */
-  driver_return_code_t cdio_eject_media (CdIo_t **p_cdio);
-
-  /**
-    Eject media in CD drive if there is a routine to do so.
-
-    @param psz_drive the name of the device to be acted upon.
-    If NULL is given as the drive, we'll use the default driver device.
-  */
-  driver_return_code_t cdio_eject_media_drive (const char *psz_drive);
-
-  /**
-    Free device list returned by cdio_get_devices or
-    cdio_get_devices_with_cap().
-
-    @param device_list list returned by cdio_get_devices or
-    cdio_get_devices_with_cap().
-
-    @see cdio_get_devices(), and cdio_get_devices_with_cap().
-
-  */
-  void cdio_free_device_list (char * device_list[]);
-
-  /**
-    Get the default CD device.
-    if \p p_cdio is \p NULL (we haven't initialized a specific device driver),
-    then find a suitable one and return the default device for that.
-
-    @param p_cdio the CD object queried
-
-    @return a string containing the default CD device or \p NULL
-    if we couldn't get a default device.
-
-    In some situations of drivers or OS's we can't find a CD device if
-    there is no media in it and it is possible for this routine to return
-    NULL even though there may be a hardware CD-ROM.
-  */
-  char * cdio_get_default_device (const CdIo_t *p_cdio);
-
-  /**
-    Return a string containing the default CD device if none is specified.
-    if \p p_driver_id is \p DRIVER_UNKNOWN or \p DRIVER_DEVICE
-    then find a suitable one set the default device for that.
-
-    \p NULL is returned if we couldn't get a default device.
-  */
-  char * cdio_get_default_device_driver (/*in/out*/ driver_id_t *p_driver_id);
-
-  /** Return an array of device names. If you want a specific
-    devices for a driver, give that device. If you want hardware
-    devices, give \p DRIVER_DEVICE and if you want all possible devices,
-    image drivers and hardware drivers give \p DRIVER_UNKNOWN.
-
-    NULL is returned if we couldn't return a list of devices.
-
-    In some situations of drivers or OS's we can't find a CD device if
-    there is no media in it and it is possible for this routine to return
-    \p NULL even though there may be a hardware CD-ROM.
-  */
-  char ** cdio_get_devices (driver_id_t driver_id);
-
-  /**
-     Get an array of device names in search_devices that have at least
-     the capabilities listed by the capabities parameter.  If
-     search_devices is \p NULL, then we'll search all possible CD drives.
-
-     Capabilities have two parts to them, a "filesystem" part and an
-     "analysis" part.
-
-     The filesystem part is mutually exclusive. For example either the
-     filesystem is at most one of the High-Sierra, UFS, or HFS,
-     ISO9660, filesystems. Valid combinations of say HFS and ISO9660
-     are specified as a separate "filesystem".
-
-     Capabilities on the other hand are not mutually exclusive. For
-     example a filesystem may have none, either, or both of the XA or
-     Rock-Ridge extension properties.
-
-     If "b_any" is set false then every capability listed in the
-     analysis portion of capabilities (i.e. not the basic filesystem)
-     must be satisfied. If no analysis capabilities are specified,
-     that's a match.
-
-     If "b_any" is set true, then if any of the analysis capabilities
-     matches, we call that a success.
-
-     In either case, in the filesystem portion different filesystem
-     either specify 0 to match any filesystem or the specific
-     filesystem type.
-
-     To find a CD-drive of any type, use the mask CDIO_FS_MATCH_ALL.
-
-     @return the array of device names or NULL if we couldn't get a
-     default device.  It is also possible to return a non NULL but
-     after dereferencing the the value is NULL. This also means nothing
-     was found.
-  */
-  char ** cdio_get_devices_with_cap (/*in*/ char *ppsz_search_devices[],
-                                     cdio_fs_anal_t capabilities, bool b_any);
-
-  /**
-     Like cdio_get_devices_with_cap() but we return the driver we found
-     as well. This is because often one wants to search for kind of drive
-     and then *open* it afterwards. Giving the driver back facilitates this,
-     and speeds things up for libcdio as well.
-  */
-  char ** cdio_get_devices_with_cap_ret (/*in*/ char* ppsz_search_devices[],
-                                         cdio_fs_anal_t capabilities,
-                                         bool b_any,
-                                         /*out*/ driver_id_t *p_driver_id);
-
-  /**
-     Like cdio_get_devices(), but we may change the p_driver_id if we
-     were given \p DRIVER_DEVICE or \p DRIVER_UNKNOWN. This is because often
-     one wants to get a drive name and then *open* it
-     afterwards. Giving the driver back facilitates this, and speeds
-     things up for libcdio as well.
-   */
-
-  char ** cdio_get_devices_ret (/*in/out*/ driver_id_t *p_driver_id);
-
-  /**
-     Get the what kind of device we've got.
-
-     @param p_cdio the CD object queried
-     @param p_read_cap pointer to return read capabilities
-     @param p_write_cap pointer to return write capabilities
-     @param p_misc_cap pointer to return miscellaneous other capabilities
-
-     In some situations of drivers or OS's we can't find a CD device if
-     there is no media in it. In this situation capabilities will show up as
-     \p NULL even though there isa hardware CD-ROM.
-  */
-  void cdio_get_drive_cap (const CdIo_t *p_cdio,
-                           cdio_drive_read_cap_t  *p_read_cap,
-                           cdio_drive_write_cap_t *p_write_cap,
-                           cdio_drive_misc_cap_t  *p_misc_cap);
-
-  /**
-     Get the drive capabilities for a specified device.
-
-     Return a list of device capabilities.
-
-     In some situations of drivers or OS's we can't find a CD device if
-     there is no media in it. In this situation capabilities will show up as
-     \p NULL even though there isa hardware CD-ROM.
-  */
-  void cdio_get_drive_cap_dev (const char *device,
-                               cdio_drive_read_cap_t  *p_read_cap,
-                               cdio_drive_write_cap_t *p_write_cap,
-                               cdio_drive_misc_cap_t  *p_misc_cap);
-
-  /**
-     Get a string containing the name of the driver in use.
-
-     @param p_cdio the CD object to be acted upon.
-
-     @return a string with driver name or NULL if CdIo_t is NULL (we
-     haven't initialized a specific device.
-  */
-  const char * cdio_get_driver_name (const CdIo_t *p_cdio);
-
-  /**
-     Return a string name for the \p driver_id.
-  */
-  const char * cdio_get_driver_name_from_id (driver_id_t driver_id);
-
-
-  /**
-     Get the driver id.
-     if \p p_cdio is \p NULL (we haven't initialized a specific device driver),
-     then return \p DRIVER_UNKNOWN.
-
-     @param p_cdio the CD object to be acted upon.
-
-     @return the driver id..
-  */
-  driver_id_t cdio_get_driver_id (const CdIo_t *p_cdio);
-
-  /**
-    Get the CD-ROM hardware info via a SCSI MMC INQUIRY command.
-    False is returned if we had an error getting the information.
-  */
-  bool cdio_get_hwinfo ( const CdIo_t *p_cdio,
-                         /*out*/ cdio_hwinfo_t *p_hw_info );
-
-
-  /**
-     Get the LSN of the first track of the last session of
-     on the CD.
-
-     @param p_cdio the CD object to be acted upon.
-     @param i_last_session pointer to the session number to be returned.
-  */
-  driver_return_code_t cdio_get_last_session (CdIo_t *p_cdio,
-                                              /*out*/ lsn_t *i_last_session);
-
-  /**
-      Find out if media has changed since the last call.
-
-      @param p_cdio the CD object to be acted upon.
-
-      @return 1 if media has changed since last call, 0 if not. Error
-      return codes are the same as \p driver_return_code_t
-   */
-  int cdio_get_media_changed(CdIo_t *p_cdio);
-
-  /** True if CD-ROM understand ATAPI commands. */
-  bool_3way_t cdio_have_atapi (CdIo_t *p_cdio);
-
-  /** Like cdio_have_xxx but uses an enumeration instead. */
-  bool cdio_have_driver (driver_id_t driver_id);
-
-  /**
-     Free any resources associated with \p p_cdio. Call this when done
-     using p_cdio and using CD reading/control operations.
-
-    @param p_cdio the CD object to eliminated.
-   */
-  void cdio_destroy (CdIo_t *p_cdio);
-
-  /**
-    Get a string describing driver_id.
-
-    @param driver_id the driver you want the description for
-    @return a string of driver description
-  */
-  const char *cdio_driver_describe (driver_id_t driver_id);
-
-  /**
-     Sets up to read from place specified by \p psz_source and
-     \p driver_id. This or cdio_open_* should be called before using any
-     other routine, except cdio_init or any routine that accesses the
-     CD-ROM drive by name. cdio_open will call cdio_init, if that
-     hasn't been done previously.
-
-     @return the cdio object or NULL on error or no device.  If NULL
-     is given as the source, we'll use the default driver device.
-  */
-  CdIo_t * cdio_open (const char *psz_source, driver_id_t driver_id);
-
-  /**
-     Sets up to read from place specified by psz_source, driver_id and
-     access mode. This or cdio_open* should be called before using any
-     other routine, except cdio_init or any routine that accesses the
-     CD-ROM drive by name. This will call cdio_init, if that hasn't
-     been done previously.
-
-     If \p NULL is given as the source, we'll use the default driver
-     device.
-
-     @return the cdio object or \p NULL on error or no device.
-  */
-  CdIo_t * cdio_open_am (const char *psz_source,
-                         driver_id_t driver_id, const char *psz_access_mode);
-
-  /**
-     Set up BIN/CUE CD disk-image for reading. Source is the .bin or
-     .cue file
-
-     @return the cdio object or \p NULL on error or no device.
-   */
-  CdIo_t * cdio_open_bincue (const char *psz_cue_name);
-
-  /**
-     Set up BIN/CUE CD disk-image for reading. Source is the .bin or
-     .cue file
-
-     @return the cdio object or \p NULL on error or no device..
-   */
-  CdIo_t * cdio_open_am_bincue (const char *psz_cue_name,
-                                const char *psz_access_mode);
-
-  /**
-     Set up cdrdao CD disk-image for reading. Source is the .toc file
-
-     @return the cdio object or \p NULL on error or no device.
-   */
-  CdIo_t * cdio_open_cdrdao (const char *psz_toc_name);
-
-  /**
-     Set up cdrdao CD disk-image for reading. Source is the .toc file
-
-     @return the cdio object or NULL on error or no device..
-  */
-  CdIo_t * cdio_open_am_cdrdao (const char *psz_toc_name,
-                                const char *psz_access_mode);
-
-  /**
-     Return a string containing the default CUE file that would
-     be used when none is specified.
-
-     @return the cdio object or \p NULL on error or no device.
-  */
-  char * cdio_get_default_device_bincue(void);
-
-  char **cdio_get_devices_bincue(void);
-
-  /**
-     @return string containing the default CUE file that would be
-     used when none is specified. \p NULL is returned on error or there
-     is no device.
-   */
-  char * cdio_get_default_device_cdrdao(void);
-
-  char **cdio_get_devices_cdrdao(void);
-
-  /**
-     Set up CD-ROM for reading. The device_name is
-     the some sort of device name.
-
-     @return the cdio object for subsequent operations.
-     \p NULL on error or there is no driver for a some sort of hardware CD-ROM.
-  */
-  CdIo_t * cdio_open_cd (const char *device_name);
-
-  /**
-     Set up CD-ROM for reading. The device_name is
-     the some sort of device name.
-
-     @return the cdio object for subsequent operations.
-     \p NULL on error or there is no driver for a some sort of hardware CD-ROM.
-  */
-  CdIo_t * cdio_open_am_cd (const char *psz_device,
+
+    @return 1 if media has changed since last call, 0 if not. Error
+    return codes are the same as \p driver_return_code_t
+ */
+int cdio_get_media_changed(CdIo_t *p_cdio);
+
+/** True if CD-ROM understand ATAPI commands. */
+bool_3way_t cdio_have_atapi(CdIo_t *p_cdio);
+
+/** Like cdio_have_xxx but uses an enumeration instead. */
+bool cdio_have_driver(driver_id_t driver_id);
+
+/**
+   Free any resources associated with \p p_cdio. Call this when done
+   using p_cdio and using CD reading/control operations.
+
+  @param p_cdio the CD object to eliminated.
+ */
+void cdio_destroy(CdIo_t *p_cdio);
+
+/**
+  Get a string describing driver_id.
+
+  @param driver_id the driver you want the description for
+  @return a string of driver description
+*/
+const char *cdio_driver_describe(driver_id_t driver_id);
+
+/**
+   Sets up to read from place specified by \p psz_source and
+   \p driver_id. This or cdio_open_* should be called before using any
+   other routine, except cdio_init or any routine that accesses the
+   CD-ROM drive by name. cdio_open will call cdio_init, if that
+   hasn't been done previously.
+
+   @return the cdio object or NULL on error or no device.  If NULL
+   is given as the source, we'll use the default driver device.
+*/
+CdIo_t *cdio_open(const char *psz_source, driver_id_t driver_id);
+
+/**
+   Sets up to read from place specified by psz_source, driver_id and
+   access mode. This or cdio_open* should be called before using any
+   other routine, except cdio_init or any routine that accesses the
+   CD-ROM drive by name. This will call cdio_init, if that hasn't
+   been done previously.
+
+   If \p NULL is given as the source, we'll use the default driver
+   device.
+
+   @return the cdio object or \p NULL on error or no device.
+*/
+CdIo_t *cdio_open_am(const char *psz_source, driver_id_t driver_id,
+                     const char *psz_access_mode);
+
+/**
+   Set up BIN/CUE CD disk-image for reading. Source is the .bin or
+   .cue file
+
+   @return the cdio object or \p NULL on error or no device.
+ */
+CdIo_t *cdio_open_bincue(const char *psz_cue_name);
+
+/**
+   Set up BIN/CUE CD disk-image for reading. Source is the .bin or
+   .cue file
+
+   @return the cdio object or \p NULL on error or no device..
+ */
+CdIo_t *cdio_open_am_bincue(const char *psz_cue_name,
                             const char *psz_access_mode);
 
-  /**
-     CDRWIN BIN/CUE CD disc-image routines. Source is the .cue file
+/**
+   Set up cdrdao CD disk-image for reading. Source is the .toc file
 
-     @return the cdio object for subsequent operations.
-     \p NULL on error.
-   */
-  CdIo_t * cdio_open_cue (const char *cue_name);
+   @return the cdio object or \p NULL on error or no device.
+ */
+CdIo_t *cdio_open_cdrdao(const char *psz_toc_name);
 
-  /**
-     Set up CD-ROM for reading using the AIX driver. The device_name is
-     the some sort of device name.
+/**
+   Set up cdrdao CD disk-image for reading. Source is the .toc file
 
-     @return the cdio object for subsequent operations.
-     \p NULL on error or there is no AIX driver.
+   @return the cdio object or NULL on error or no device..
+*/
+CdIo_t *cdio_open_am_cdrdao(const char *psz_toc_name,
+                            const char *psz_access_mode);
 
-     @see cdio_open()
-   */
-  CdIo_t * cdio_open_am_aix (const char *psz_source,
+/**
+   Return a string containing the default CUE file that would
+   be used when none is specified.
+
+   @return the cdio object or \p NULL on error or no device.
+*/
+char *cdio_get_default_device_bincue(void);
+
+char **cdio_get_devices_bincue(void);
+
+/**
+   @return string containing the default CUE file that would be
+   used when none is specified. \p NULL is returned on error or there
+   is no device.
+ */
+char *cdio_get_default_device_cdrdao(void);
+
+char **cdio_get_devices_cdrdao(void);
+
+/**
+   Set up CD-ROM for reading. The device_name is
+   the some sort of device name.
+
+   @return the cdio object for subsequent operations.
+   \p NULL on error or there is no driver for a some sort of hardware CD-ROM.
+*/
+CdIo_t *cdio_open_cd(const char *device_name);
+
+/**
+   Set up CD-ROM for reading. The device_name is
+   the some sort of device name.
+
+   @return the cdio object for subsequent operations.
+   \p NULL on error or there is no driver for a some sort of hardware CD-ROM.
+*/
+CdIo_t *cdio_open_am_cd(const char *psz_device, const char *psz_access_mode);
+
+/**
+   CDRWIN BIN/CUE CD disc-image routines. Source is the .cue file
+
+   @return the cdio object for subsequent operations.
+   \p NULL on error.
+ */
+CdIo_t *cdio_open_cue(const char *cue_name);
+
+/**
+   Set up CD-ROM for reading using the AIX driver. The device_name is
+   the some sort of device name.
+
+   @return the cdio object for subsequent operations.
+   \p NULL on error or there is no AIX driver.
+
+   @see cdio_open()
+ */
+CdIo_t *cdio_open_am_aix(const char *psz_source, const char *psz_access_mode);
+
+/**
+   Set up CD-ROM for reading using the AIX driver. The device_name is
+   the some sort of device name.
+
+   @return the cdio object for subsequent operations.
+   \p NULL on error or there is no AIX driver.
+
+   @see cdio_open()
+ */
+CdIo_t *cdio_open_aix(const char *psz_source);
+
+/**
+   Return a string containing the default device name that the AIX
+   driver would use when none is specified.
+
+   @return the cdio object for subsequent operations.
+   \p NULL on error or there is no AIX driver.
+
+   @see cdio_open_cd(), cdio_open()
+ */
+char *cdio_get_default_device_aix(void);
+
+/**
+   Return a list of all of the CD-ROM devices that the AIX driver
+   can find.
+
+   In some situations of drivers or OS's we can't find a CD device
+   if there is no media in it and it is possible for this routine to
+   return \p NULL even though there may be a hardware CD-ROM.
+ */
+char **cdio_get_devices_aix(void);
+
+/**
+   Set up CD-ROM for reading using the FreeBSD driver. The
+   device_name is the some sort of device name.
+
+   NULL is returned on error or there is no FreeBSD driver.
+
+   @see cdio_open_cd(), cdio_open()
+ */
+CdIo_t *cdio_open_freebsd(const char *paz_psz_source);
+
+/**
+   Set up CD-ROM for reading using the FreeBSD driver. The
+   device_name is the some sort of device name.
+
+   NULL is returned on error or there is no FreeBSD driver.
+
+   @see cdio_open_cd(), cdio_open()
+ */
+CdIo_t *cdio_open_am_freebsd(const char *psz_source,
                              const char *psz_access_mode);
 
-  /**
-     Set up CD-ROM for reading using the AIX driver. The device_name is
-     the some sort of device name.
+/**
+   Return a string containing the default device name that the
+   FreeBSD driver would use when none is specified.
 
-     @return the cdio object for subsequent operations.
-     \p NULL on error or there is no AIX driver.
+   NULL is returned on error or there is no CD-ROM device.
+ */
+char *cdio_get_default_device_freebsd(void);
 
-     @see cdio_open()
-   */
-  CdIo_t * cdio_open_aix (const char *psz_source);
+/**
+   Return a list of all of the CD-ROM devices that the FreeBSD
+   driver can find.
+ */
+char **cdio_get_devices_freebsd(void);
 
-  /**
-     Return a string containing the default device name that the AIX
-     driver would use when none is specified.
+/**
+   Set up CD-ROM for reading using the GNU/Linux driver. The
+   device_name is the some sort of device name.
 
-     @return the cdio object for subsequent operations.
-     \p NULL on error or there is no AIX driver.
+   @return the cdio object for subsequent operations.
+   NULL on error or there is no GNU/Linux driver.
 
-     @see cdio_open_cd(), cdio_open()
-   */
-  char * cdio_get_default_device_aix(void);
+   In some situations of drivers or OS's we can't find a CD device if
+   there is no media in it and it is possible for this routine to return
+   NULL even though there may be a hardware CD-ROM.
+ */
+CdIo_t *cdio_open_linux(const char *psz_source);
 
-  /**
-     Return a list of all of the CD-ROM devices that the AIX driver
-     can find.
+/**
+   Set up CD-ROM for reading using the GNU/Linux driver. The
+   device_name is the some sort of device name.
 
-     In some situations of drivers or OS's we can't find a CD device
-     if there is no media in it and it is possible for this routine to
-     return \p NULL even though there may be a hardware CD-ROM.
-   */
-  char **cdio_get_devices_aix(void);
+   @return the cdio object for subsequent operations.
+   NULL on error or there is no GNU/Linux driver.
+ */
+CdIo_t *cdio_open_am_linux(const char *psz_source, const char *access_mode);
 
-  /**
-     Set up CD-ROM for reading using the FreeBSD driver. The
-     device_name is the some sort of device name.
+/**
+   Return a string containing the default device name that the
+   GNU/Linux driver would use when none is specified. A scan is made
+   for CD-ROM drives with CDs in them.
 
-     NULL is returned on error or there is no FreeBSD driver.
+   NULL is returned on error or there is no CD-ROM device.
 
-     @see cdio_open_cd(), cdio_open()
-   */
-  CdIo_t * cdio_open_freebsd (const char *paz_psz_source);
+   In some situations of drivers or OS's we can't find a CD device if
+   there is no media in it and it is possible for this routine to return
+   NULL even though there may be a hardware CD-ROM.
 
-  /**
-     Set up CD-ROM for reading using the FreeBSD driver. The
-     device_name is the some sort of device name.
+   @see cdio_open_cd, cdio_open
+ */
+char *cdio_get_default_device_linux(void);
 
-     NULL is returned on error or there is no FreeBSD driver.
+/**
+   Return a list of all of the CD-ROM devices that the GNU/Linux
+   driver can find.
+ */
+char **cdio_get_devices_linux(void);
 
-     @see cdio_open_cd(), cdio_open()
-   */
-  CdIo_t * cdio_open_am_freebsd (const char *psz_source,
-                                 const char *psz_access_mode);
+/**
+   Set up CD-ROM for reading using the Sun Solaris driver. The
+   device_name is the some sort of device name.
 
-  /**
-     Return a string containing the default device name that the
-     FreeBSD driver would use when none is specified.
+   @return the cdio object for subsequent operations.
+   \p NULL on error or there is no Solaris driver.
+ */
+CdIo_t *cdio_open_solaris(const char *psz_source);
 
-     NULL is returned on error or there is no CD-ROM device.
-   */
-  char * cdio_get_default_device_freebsd(void);
+/**
+   Set up CD-ROM for reading using the Sun Solaris driver. The
+   device_name is the some sort of device name.
 
-  /**
-     Return a list of all of the CD-ROM devices that the FreeBSD
-     driver can find.
-   */
-  char **cdio_get_devices_freebsd(void);
-
-  /**
-     Set up CD-ROM for reading using the GNU/Linux driver. The
-     device_name is the some sort of device name.
-
-     @return the cdio object for subsequent operations.
-     NULL on error or there is no GNU/Linux driver.
-
-     In some situations of drivers or OS's we can't find a CD device if
-     there is no media in it and it is possible for this routine to return
-     NULL even though there may be a hardware CD-ROM.
-   */
-  CdIo_t * cdio_open_linux (const char *psz_source);
-
-  /**
-     Set up CD-ROM for reading using the GNU/Linux driver. The
-     device_name is the some sort of device name.
-
-     @return the cdio object for subsequent operations.
-     NULL on error or there is no GNU/Linux driver.
-   */
-  CdIo_t * cdio_open_am_linux (const char *psz_source,
-                               const char *access_mode);
-
-  /**
-     Return a string containing the default device name that the
-     GNU/Linux driver would use when none is specified. A scan is made
-     for CD-ROM drives with CDs in them.
-
-     NULL is returned on error or there is no CD-ROM device.
-
-     In some situations of drivers or OS's we can't find a CD device if
-     there is no media in it and it is possible for this routine to return
-     NULL even though there may be a hardware CD-ROM.
-
-     @see cdio_open_cd, cdio_open
-   */
-  char * cdio_get_default_device_linux(void);
-
-  /**
-     Return a list of all of the CD-ROM devices that the GNU/Linux
-     driver can find.
-   */
-  char **cdio_get_devices_linux(void);
-
-  /**
-     Set up CD-ROM for reading using the Sun Solaris driver. The
-     device_name is the some sort of device name.
-
-     @return the cdio object for subsequent operations.
-     \p NULL on error or there is no Solaris driver.
-   */
-  CdIo_t * cdio_open_solaris (const char *psz_source);
-
-  /**
-     Set up CD-ROM for reading using the Sun Solaris driver. The
-     device_name is the some sort of device name.
-
-     @return the cdio object for subsequent operations.
-     \p NULL on error or there is no Solaris driver.
-   */
-  CdIo_t * cdio_open_am_solaris (const char *psz_source,
-                                 const char *psz_access_mode);
-
-  /**
-     Return a string containing the default device name that the
-     Solaris driver would use when none is specified. A scan is made
-     for CD-ROM drives with CDs in them.
-
-     \p NULL is returned on error or there is no CD-ROM device.
-
-     In some situations of drivers or OS's we can't find a CD device if
-     there is no media in it and it is possible for this routine to return
-     \p NULL even though there may be a hardware CD-ROM.
-
-     @see cdio_open_cd(), cdio_open()
-   */
-  char * cdio_get_default_device_solaris(void);
-
-  /**
-     Return a list of all of the CD-ROM devices that the Solaris
-     driver can find.
-   */
-  char **cdio_get_devices_solaris(void);
-
-  /**
-     Set up CD-ROM for reading using the Apple OSX driver. The
-     device_name is the some sort of device name.
-
-     \p NULL is returned on error or there is no OSX driver.
-
-     In some situations of drivers or OS's we can't find a CD device if
-     there is no media in it and it is possible for this routine to return
-     NULL even though there may be a hardware CD-ROM.
-
-     @see cdio_open_cd(), cdio_open()
-   */
-  CdIo_t * cdio_open_osx (const char *psz_source);
-
-  /**
-     Set up CD-ROM for reading using the Apple OSX driver. The
-     device_name is the some sort of device name.
-
-     NULL is returned on error or there is no OSX driver.
-
-     @see cdio_open_cd(), cdio_open()
-   */
-  CdIo_t * cdio_open_am_osx (const char *psz_source,
+   @return the cdio object for subsequent operations.
+   \p NULL on error or there is no Solaris driver.
+ */
+CdIo_t *cdio_open_am_solaris(const char *psz_source,
                              const char *psz_access_mode);
 
-  /**
-     Return a string containing the default device name that the OSX
-     driver would use when none is specified. A scan is made for
-     CD-ROM drives with CDs in them.
+/**
+   Return a string containing the default device name that the
+   Solaris driver would use when none is specified. A scan is made
+   for CD-ROM drives with CDs in them.
 
-     In some situations of drivers or OS's we can't find a CD device if
-     there is no media in it and it is possible for this routine to return
-     NULL even though there may be a hardware CD-ROM.
-   */
-  char * cdio_get_default_device_osx(void);
+   \p NULL is returned on error or there is no CD-ROM device.
 
-  /**
-     Return a list of all of the CD-ROM devices that the OSX driver
-     can find.
-   */
-  char **cdio_get_devices_osx(void);
+   In some situations of drivers or OS's we can't find a CD device if
+   there is no media in it and it is possible for this routine to return
+   \p NULL even though there may be a hardware CD-ROM.
 
-  /**
-     Set up CD-ROM for reading using the Microsoft Windows driver. The
-     device_name is the some sort of device name.
+   @see cdio_open_cd(), cdio_open()
+ */
+char *cdio_get_default_device_solaris(void);
 
-     In some situations of drivers or OS's we can't find a CD device if
-     there is no media in it and it is possible for this routine to return
-     NULL even though there may be a hardware CD-ROM.
-   */
-  CdIo_t * cdio_open_win32 (const char *psz_source);
+/**
+   Return a list of all of the CD-ROM devices that the Solaris
+   driver can find.
+ */
+char **cdio_get_devices_solaris(void);
 
-  /**
-     Set up CD-ROM for reading using the Microsoft Windows driver. The
-     device_name is the some sort of device name.
+/**
+   Set up CD-ROM for reading using the Apple OSX driver. The
+   device_name is the some sort of device name.
 
-     NULL is returned on error or there is no Microsoft Windows driver.
-   */
-  CdIo_t * cdio_open_am_win32 (const char *psz_source,
-                               const char *psz_access_mode);
+   \p NULL is returned on error or there is no OSX driver.
 
-  /**
-     Return a string containing the default device name that the
-     Win32 driver would use when none is specified. A scan is made
-     for CD-ROM drives with CDs in them.
+   In some situations of drivers or OS's we can't find a CD device if
+   there is no media in it and it is possible for this routine to return
+   NULL even though there may be a hardware CD-ROM.
 
-     In some situations of drivers or OS's we can't find a CD device
-     if there is no media in it and it is possible for this routine to
-     return NULL even though there may be a hardware CD-ROM.
+   @see cdio_open_cd(), cdio_open()
+ */
+CdIo_t *cdio_open_osx(const char *psz_source);
 
-     @see cdio_open_cd(), cdio_open()
-   */
-  char * cdio_get_default_device_win32(void);
+/**
+   Set up CD-ROM for reading using the Apple OSX driver. The
+   device_name is the some sort of device name.
 
-  char **cdio_get_devices_win32(void);
+   NULL is returned on error or there is no OSX driver.
 
-  /**
-     Set up CD-ROM for reading using the Nero driver. The device_name
-     is the some sort of device name.
+   @see cdio_open_cd(), cdio_open()
+ */
+CdIo_t *cdio_open_am_osx(const char *psz_source, const char *psz_access_mode);
 
-     @return true on success; NULL on error or there is no Nero driver.
-   */
-  CdIo_t * cdio_open_nrg (const char *psz_source);
+/**
+   Return a string containing the default device name that the OSX
+   driver would use when none is specified. A scan is made for
+   CD-ROM drives with CDs in them.
 
-  /**
-     Set up CD-ROM for reading using the Nero driver. The device_name
-     is the some sort of device name.
+   In some situations of drivers or OS's we can't find a CD device if
+   there is no media in it and it is possible for this routine to return
+   NULL even though there may be a hardware CD-ROM.
+ */
+char *cdio_get_default_device_osx(void);
 
-     @return true on success; NULL on error or there is no Nero driver.
-   */
-  CdIo_t * cdio_open_am_nrg (const char *psz_source,
-                             const char *psz_access_mode);
+/**
+   Return a list of all of the CD-ROM devices that the OSX driver
+   can find.
+ */
+char **cdio_get_devices_osx(void);
 
-  /**
-     Get a string containing the default device name that the NRG
-     driver would use when none is specified. A scan is made for NRG
-     disk images in the current directory.
+/**
+   Set up CD-ROM for reading using the Microsoft Windows driver. The
+   device_name is the some sort of device name.
 
-     @return string containing the default device. NULL on error or
-     there is no CD-ROM device.
-   */
-  char * cdio_get_default_device_nrg(void);
+   In some situations of drivers or OS's we can't find a CD device if
+   there is no media in it and it is possible for this routine to return
+   NULL even though there may be a hardware CD-ROM.
+ */
+CdIo_t *cdio_open_win32(const char *psz_source);
 
-  char **cdio_get_devices_nrg(void);
+/**
+   Set up CD-ROM for reading using the Microsoft Windows driver. The
+   device_name is the some sort of device name.
 
-  /**
+   NULL is returned on error or there is no Microsoft Windows driver.
+ */
+CdIo_t *cdio_open_am_win32(const char *psz_source, const char *psz_access_mode);
 
-     Determine if bin_name is the bin file part of  a CDRWIN CD disk image.
+/**
+   Return a string containing the default device name that the
+   Win32 driver would use when none is specified. A scan is made
+   for CD-ROM drives with CDs in them.
 
-     @param bin_name location of presumed CDRWIN bin image file.
-     @return the corresponding CUE file if bin_name is a BIN file or
-     \p NULL if not a BIN file.
-  */
-  char *cdio_is_binfile(const char *bin_name);
+   In some situations of drivers or OS's we can't find a CD device
+   if there is no media in it and it is possible for this routine to
+   return NULL even though there may be a hardware CD-ROM.
 
-  /**
-     Determine if cue_name is the cue sheet for a CDRWIN CD disk image.
+   @see cdio_open_cd(), cdio_open()
+ */
+char *cdio_get_default_device_win32(void);
 
-     @return corresponding BIN file if cue_name is a CDRWIN cue file or
-     \p NULL if not a CUE file.
-  */
-  char *cdio_is_cuefile(const char *cue_name);
+char **cdio_get_devices_win32(void);
 
-  /**
-    Determine if psg_nrg is a Nero CD disc image.
+/**
+   Set up CD-ROM for reading using the Nero driver. The device_name
+   is the some sort of device name.
 
-    @param psz_nrg location of presumed NRG image file.
-    @return true if psz_nrg is a Nero NRG image or false
-    if not a NRG image.
-  */
-  bool cdio_is_nrg(const char *psz_nrg);
+   @return true on success; NULL on error or there is no Nero driver.
+ */
+CdIo_t *cdio_open_nrg(const char *psz_source);
 
-  /**
-     Determine if psz_toc is a TOC file for a cdrdao CD disc image.
+/**
+   Set up CD-ROM for reading using the Nero driver. The device_name
+   is the some sort of device name.
 
-     @param psz_toc location of presumed TOC image file.
-     @return true if toc_name is a cdrdao TOC file or false
-     if not a TOC file.
-  */
-  bool cdio_is_tocfile(const char *psz_toc);
+   @return true on success; NULL on error or there is no Nero driver.
+ */
+CdIo_t *cdio_open_am_nrg(const char *psz_source, const char *psz_access_mode);
 
-  /**
-     Determine if psz_source refers to a real hardware CD-ROM.
+/**
+   Get a string containing the default device name that the NRG
+   driver would use when none is specified. A scan is made for NRG
+   disk images in the current directory.
 
-     @param psz_source location name of object
-     @param driver_id   driver for reading object. Use DRIVER_UNKNOWN if you
-     don't know what driver to use.
-     @return true if psz_source is a device; If false is returned we
-     could have a CD disk image.
-  */
-  bool cdio_is_device(const char *psz_source, driver_id_t driver_id);
+   @return string containing the default device. NULL on error or
+   there is no CD-ROM device.
+ */
+char *cdio_get_default_device_nrg(void);
 
-  /**
-    Set the blocksize for subsequent reads.
-  */
-  driver_return_code_t cdio_set_blocksize ( const CdIo_t *p_cdio,
-                                            int i_blocksize );
+char **cdio_get_devices_nrg(void);
 
-  /**
-     Set the drive speed.
+/**
 
-     @param p_cdio          CD structure set by cdio_open().
+   Determine if bin_name is the bin file part of  a CDRWIN CD disk image.
 
-    @param i_drive_speed speed in CD-ROM speed units. Note this not
-                         Kbs as would be used in the MMC spec or in
-                         mmc_set_speed(). To convert CD-ROM speed
-                         units to Kbs, multiply the number by 176 (for
-                         raw data) and by 150 (for filesystem
-                         data). On many CD-ROM drives, specifying a
-                         value too large will result in using the
-                         fastest speed.
+   @param bin_name location of presumed CDRWIN bin image file.
+   @return the corresponding CUE file if bin_name is a BIN file or
+   \p NULL if not a BIN file.
+*/
+char *cdio_is_binfile(const char *bin_name);
 
-      @see mmc_set_speed() and mmc_set_drive_speed()
-  */
-  driver_return_code_t cdio_set_speed ( const CdIo_t *p_cdio,
-                                        int i_drive_speed );
+/**
+   Determine if cue_name is the cue sheet for a CDRWIN CD disk image.
 
-  /**
-     Get the value associated with key.
+   @return corresponding BIN file if cue_name is a CDRWIN cue file or
+   \p NULL if not a CUE file.
+*/
+char *cdio_is_cuefile(const char *cue_name);
 
-     @param p_cdio the CD object queried @param key the key to
-     retrieve @return the value associated with "key", \p NULL if \p
-     p_cdio is \p NULL, or "key" does not exist.
-  */
-  const char * cdio_get_arg (const CdIo_t *p_cdio,  const char key[]);
+/**
+  Determine if psg_nrg is a Nero CD disc image.
 
-  /**
-     Set the arg "key" with "value" in "p_cdio".
+  @param psz_nrg location of presumed NRG image file.
+  @return true if psz_nrg is a Nero NRG image or false
+  if not a NRG image.
+*/
+bool cdio_is_nrg(const char *psz_nrg);
 
-     @param p_cdio the CD object to set
-     @param key the key to set
-     @param value the value to assocaiate with key
-  */
-  driver_return_code_t cdio_set_arg (CdIo_t *p_cdio, const char key[],
-                                     const char value[]);
+/**
+   Determine if psz_toc is a TOC file for a cdrdao CD disc image.
 
-  /**
-    Initialize CD Reading and control routines. Should be called first.
-  */
-  bool cdio_init(void);
+   @param psz_toc location of presumed TOC image file.
+   @return true if toc_name is a cdrdao TOC file or false
+   if not a TOC file.
+*/
+bool cdio_is_tocfile(const char *psz_toc);
 
-  /**
-     Get access to the underlying device file descriptor of the driver.
+/**
+   Determine if psz_source refers to a real hardware CD-ROM.
 
-      @param p_cdio the CD object.
-      @return the file descriptor or DRIVER_OP_UNSUPPORTED if the device
-      does not use file descriptors.
-  */
-  int cdio_get_device_fd (CdIo_t *p_cdio);
+   @param psz_source location name of object
+   @param driver_id   driver for reading object. Use DRIVER_UNKNOWN if you
+   don't know what driver to use.
+   @return true if psz_source is a device; If false is returned we
+   could have a CD disk image.
+*/
+bool cdio_is_device(const char *psz_source, driver_id_t driver_id);
+
+/**
+  Set the blocksize for subsequent reads.
+*/
+driver_return_code_t cdio_set_blocksize(const CdIo_t *p_cdio, int i_blocksize);
+
+/**
+   Set the drive speed.
+
+   @param p_cdio          CD structure set by cdio_open().
+
+  @param i_drive_speed speed in CD-ROM speed units. Note this not
+                       Kbs as would be used in the MMC spec or in
+                       mmc_set_speed(). To convert CD-ROM speed
+                       units to Kbs, multiply the number by 176 (for
+                       raw data) and by 150 (for filesystem
+                       data). On many CD-ROM drives, specifying a
+                       value too large will result in using the
+                       fastest speed.
+
+    @see mmc_set_speed() and mmc_set_drive_speed()
+*/
+driver_return_code_t cdio_set_speed(const CdIo_t *p_cdio, int i_drive_speed);
+
+/**
+   Get the value associated with key.
+
+   @param p_cdio the CD object queried @param key the key to
+   retrieve @return the value associated with "key", \p NULL if \p
+   p_cdio is \p NULL, or "key" does not exist.
+*/
+const char *cdio_get_arg(const CdIo_t *p_cdio, const char key[]);
+
+/**
+   Set the arg "key" with "value" in "p_cdio".
+
+   @param p_cdio the CD object to set
+   @param key the key to set
+   @param value the value to assocaiate with key
+*/
+driver_return_code_t cdio_set_arg(CdIo_t *p_cdio, const char key[],
+                                  const char value[]);
+
+/**
+  Initialize CD Reading and control routines. Should be called first.
+*/
+bool cdio_init(void);
+
+/**
+   Get access to the underlying device file descriptor of the driver.
+
+    @param p_cdio the CD object.
+    @return the file descriptor or DRIVER_OP_UNSUPPORTED if the device
+    does not use file descriptors.
+*/
+int cdio_get_device_fd(CdIo_t *p_cdio);
 
 #ifdef __cplusplus
 }
@@ -971,10 +962,10 @@ extern "C" {
    values to be recorded in debug symbol tables. They are used to
    allow one to refer to the enumeration value names in the typedefs
    above in a debugger and debugger expressions.  */
-extern cdio_drive_cap_misc_t          debug_cdio_drive_cap_misc;
-extern cdio_drive_cap_read_t          debug_cdio_drive_cap_read_t;
-extern cdio_drive_cap_write_t         debug_drive_cap_write_t;
-extern cdio_mmc_hw_len_t              debug_cdio_mmc_hw_len;
-extern cdio_src_category_mask_t       debug_cdio_src_category_mask;
+extern cdio_drive_cap_misc_t debug_cdio_drive_cap_misc;
+extern cdio_drive_cap_read_t debug_cdio_drive_cap_read_t;
+extern cdio_drive_cap_write_t debug_drive_cap_write_t;
+extern cdio_mmc_hw_len_t debug_cdio_mmc_hw_len;
+extern cdio_src_category_mask_t debug_cdio_src_category_mask;
 
 #endif /* CDIO_DEVICE_H_ */

--- a/include/cdio/dvd.h
+++ b/include/cdio/dvd.h
@@ -42,7 +42,7 @@ typedef enum cdio_dvd_structure {
 } cdio_dvd_structure;
 
 /**
-    Media definitions for "DVD Book" from MMC-6 Table 399, page 403
+    Media definitions for "DVD Book" from MMC-6 draft 2g, Table 399, page 403
     (PDF page 451).
 */
 typedef enum cdio_dvd_book {

--- a/include/cdio/dvd.h
+++ b/include/cdio/dvd.h
@@ -20,7 +20,7 @@
    \file dvd.h
    \brief Definitions for DVD access.
 
-   The documents we make use of are described Multi-Media Commands
+   The documents we make use of are described in Multi-Media Commands
    (MMC). We will use the MMC-6 draft 2g circa 2009 described in
    https://www.13thmonkey.org/documentation/SCSI/mmc6r02g.pdf
 */

--- a/include/cdio/ecma_167.h
+++ b/include/cdio/ecma_167.h
@@ -42,7 +42,7 @@
  * SUCH DAMAGE.
  */
 
-/*!
+/**
  * \file ecma_167.h
  *
  * \brief Definitions based on ECMA-167 3rd edition (June 1997)
@@ -106,11 +106,11 @@ typedef enum {
   CHARSPEC_TYPE_CS8 = 0x08,     /**< Section 1/7.2.10 */
 } udf_charspec_enum_t;
 
-typedef uint8_t  udf_Uint8_t;  /*! Section 1/7/1.1 */
-typedef uint16_t udf_Uint16_t; /*! Section 1/7.1.3 */
-typedef uint32_t udf_Uint32_t; /*! Section 1/7.1.5 */
-typedef uint64_t udf_Uint64_t; /*! Section 1/7.1.7 */
-typedef char     udf_dstring;  /*! Section 1/7.1.12 */
+typedef uint8_t  udf_Uint8_t;  /** Section 1/7/1.1 */
+typedef uint16_t udf_Uint16_t; /** Section 1/7.1.3 */
+typedef uint32_t udf_Uint32_t; /** Section 1/7.1.5 */
+typedef uint64_t udf_Uint64_t; /** Section 1/7.1.7 */
+typedef char     udf_dstring;  /** Section 1/7.1.12 */
 
 #define UDF_LENGTH_MASK 0x3fffffff
 

--- a/include/cdio/iso9660.h
+++ b/include/cdio/iso9660.h
@@ -20,7 +20,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/*!
+/**
  * \file iso9660.h
  *
  * \brief The top-level interface header for libiso9660: the ISO-9660
@@ -46,17 +46,17 @@ These are described in Section 7 of the ISO 9660 (or ECMA 119)
 specification.
 */
 
-typedef uint8_t  iso711_t; /*! See section 7.1.1 */
-typedef int8_t   iso712_t; /*! See section 7.1.2 */
-typedef uint16_t iso721_t; /*! See section 7.2.1 */
-typedef uint16_t iso722_t; /*! See section 7.2.2 */
-typedef uint32_t iso723_t; /*! See section 7.2.3 */
-typedef uint32_t iso731_t; /*! See section 7.3.1 */
-typedef uint32_t iso732_t; /*! See section 7.3.2 */
-typedef uint64_t iso733_t; /*! See section 7.3.3 */
+typedef uint8_t  iso711_t; /** See section 7.1.1 */
+typedef int8_t   iso712_t; /** See section 7.1.2 */
+typedef uint16_t iso721_t; /** See section 7.2.1 */
+typedef uint16_t iso722_t; /** See section 7.2.2 */
+typedef uint32_t iso723_t; /** See section 7.2.3 */
+typedef uint32_t iso731_t; /** See section 7.3.1 */
+typedef uint32_t iso732_t; /** See section 7.3.2 */
+typedef uint64_t iso733_t; /** See section 7.3.3 */
 
-typedef char     achar_t;  /*! See section 7.4.1 */
-typedef char     dchar_t;  /*! See section 7.4.1 */
+typedef char     achar_t;  /** See section 7.4.1 */
+typedef char     dchar_t;  /** See section 7.4.1 */
 
 #ifndef EMPTY_ARRAY_SIZE
 #define EMPTY_ARRAY_SIZE 0
@@ -74,7 +74,7 @@ typedef char     dchar_t;  /*! See section 7.4.1 */
 #define MIN_TRACK_SIZE 4*75
 #define MIN_ISO_SIZE MIN_TRACK_SIZE
 
-/*! The following isn't really an enumeration one would really use in a
+/** The following isn't really an enumeration one would really use in a
     program; things are done this way so that in a debugger, one can
     refer to the enumeration value names, such as in a debugger
     expression and get something. With the more common \#define
@@ -97,13 +97,13 @@ extern enum iso_enum1_s {
 
 } iso_enums1;
 
-/*! An enumeration for some of the ISO_* \#defines below. This isn't
+/** An enumeration for some of the ISO_* \#defines below. This isn't
     really an enumeration one would really use in a program, it is here
     to be helpful in debuggers, where you just have to refer to the
     ISO_*_ names and get something.
   */
 
-/*! ISO 9660 directory flags. */
+/** ISO 9660 directory flags. */
 extern enum iso_flag_enum_s {
   ISO_FILE            =   0,   /**<  Not really a flag...                */
   ISO_EXISTENCE       =   1,   /**< Do not make existence known (hidden) */
@@ -116,7 +116,7 @@ extern enum iso_flag_enum_s {
   ISO_MULTIEXTENT     = 128,   /**< Not final entry of a mult. ext. file */
 } iso_flag_enums;
 
-/*! Volume descriptor types */
+/** Volume descriptor types */
 extern enum iso_vd_enum_s {
   ISO_VD_BOOT_RECORD   =  0,  /**< CD is bootable */
   ISO_VD_PRIMARY       =  1,  /**< Is in any ISO-9660 */
@@ -126,7 +126,7 @@ extern enum iso_vd_enum_s {
 } iso_vd_enums;
 
 
-/*!
+/**
    An ISO filename is:
    <em>abcd</em>.<em>eee</em> ->
    <em>filename</em>.<em>ext</em>;<em>version#</em>
@@ -144,19 +144,19 @@ extern enum iso_vd_enum_s {
 
 */
 
-/*! \brief Maximum number of characters in a publisher id. */
+/** \brief Maximum number of characters in a publisher id. */
 #define ISO_MAX_PUBLISHER_ID 128
 
-/*! \brief Maximum number of characters in an application id. */
+/** \brief Maximum number of characters in an application id. */
 #define ISO_MAX_APPLICATION_ID 128
 
-/*! \brief Maximum number of characters in a volume id. */
+/** \brief Maximum number of characters in a volume id. */
 #define ISO_MAX_VOLUME_ID 32
 
-/*! \brief Maximum number of characters in a volume-set id. */
+/** \brief Maximum number of characters in a volume-set id. */
 #define ISO_MAX_VOLUMESET_ID 128
 
-/*! String inside frame which identifies an ISO 9660 filesystem. This
+/** String inside frame which identifies an ISO 9660 filesystem. This
     string is the "id" field of an iso9660_pvd_t or an iso9660_svd_t.
 */
 extern const char ISO_STANDARD_ID[sizeof("CD001")-1];
@@ -178,7 +178,7 @@ typedef enum strncpy_pad_check {
 
 PRAGMA_BEGIN_PACKED
 
-/*!
+/**
   \brief ISO-9660 shorter-format time structure. See ECMA 9.1.5.
 
   @see iso9660_dtime
@@ -197,7 +197,7 @@ struct  iso9660_dtime_s {
 
 typedef struct iso9660_dtime_s  iso9660_dtime_t;
 
-/*!
+/**
   \brief ISO-9660 longer-format time structure.
 
   Section 8.4.26.1 of ECMA 119. All values are encoded as character
@@ -233,7 +233,7 @@ typedef struct iso9660_stat_s   iso9660_stat_t;
 
 #include <cdio/rock.h>
 
-/*! \brief Format of an ISO-9660 directory record
+/** \brief Format of an ISO-9660 directory record
 
  Section 9.1 of ECMA 119.
 
@@ -248,32 +248,32 @@ typedef struct iso9660_stat_s   iso9660_stat_t;
   @see iso9660_stat
 */
 struct iso9660_dir_s {
-  iso711_t         length;            /*! Length of Directory record (9.1.1) */
-  iso711_t         xa_length;         /*! XA length if XA is used. Otherwise
+  iso711_t         length;            /** Length of Directory record (9.1.1) */
+  iso711_t         xa_length;         /** XA length if XA is used. Otherwise
                                           zero. (9.1.2)  */
-  iso733_t         extent;            /*! LBA of first local block allocated
+  iso733_t         extent;            /** LBA of first local block allocated
                                           to the extent */
-  iso733_t         size;              /*! data length of File Section. This
+  iso733_t         size;              /** data length of File Section. This
                                           does not include the length of
                                           any XA Records. (9.1.2) */
-  iso9660_dtime_t  recording_time;    /*! Recording date and time (9.1.3) */
-  uint8_t          file_flags;        /*! If no XA then zero. If a directory,
+  iso9660_dtime_t  recording_time;    /** Recording date and time (9.1.3) */
+  uint8_t          file_flags;        /** If no XA then zero. If a directory,
                                         then bits 2,3 and 7 are zero.
                                         (9.1.6) */
-  iso711_t         file_unit_size;    /*! File Unit size for the File
+  iso711_t         file_unit_size;    /** File Unit size for the File
                                         Section if the File Section
                                         is recorded in interleaved
                                         mode. Otherwise zero. (9.1.7) */
-  iso711_t         interleave_gap;    /*! Interleave Gap size for the
+  iso711_t         interleave_gap;    /** Interleave Gap size for the
                                         File Section if the File
                                         Section is interleaved. Otherwise
                                         zero. (9.1.8) */
-  iso723_t volume_sequence_number;    /*! Ordinal number of the volume
+  iso723_t volume_sequence_number;    /** Ordinal number of the volume
                                           in the Volume Set on which
                                           the Extent described by this
                                           Directory Record is
                                           recorded. (9.1.9) */
-/*! MSVC compilers cannot handle a zero sized array in the middle
+/** MSVC compilers cannot handle a zero sized array in the middle
     of a struct, and iso9660_dir_s is reused within iso9660_pvd_s.
     Therefore, instead of defining:
        iso711_t filename_len;
@@ -287,7 +287,7 @@ struct iso9660_dir_s {
   } filename;
 } GNUC_PACKED;
 
-/*!
+/**
   \brief ISO-9660 Primary Volume Descriptor.
  */
 struct iso9660_pvd_s {
@@ -392,7 +392,7 @@ struct iso9660_pvd_s {
 
 typedef struct iso9660_pvd_s  iso9660_pvd_t;
 
-/*!
+/**
   \brief ISO-9660 Supplementary Volume Descriptor.
 
   This is used for Joliet Extensions and is almost the same as the
@@ -508,19 +508,19 @@ typedef struct iso9660_svd_s  iso9660_svd_t;
 
 PRAGMA_END_PACKED
 
-/*! \brief A data type for a list of ISO9660
+/** \brief A data type for a list of ISO9660
   statbuf file pointers returned from the various
   Cdio iso9660 readdir routines.
  */
 typedef CdioList_t CdioISO9660FileList_t;
 
-/*! \brief A data type for a list of ISO9660
+/** \brief A data type for a list of ISO9660
   statbuf drectory pointer returned from the variious
   Cdio iso9660 readdir routines.
  */
 typedef CdioList_t CdioISO9660DirList_t;
 
-/*! \brief Unix stat-like version of iso9660_dir
+/** \brief Unix stat-like version of iso9660_dir
 
    The iso9660_stat structure is not part of the ISO-9660
    specification. We use it for our to communicate information
@@ -572,7 +572,7 @@ struct iso9660_stat_s { /* big endian!! */
     of extensions we allow, eg. Joliet, Rock Ridge, etc. */
 typedef uint8_t iso_extension_mask_t;
 
-/*! An enumeration for some of the ISO_EXTENSION_* \#defines below. This isn't
+/** An enumeration for some of the ISO_EXTENSION_* \#defines below. This isn't
     really an enumeration one would really use in a program it is here
     to be helpful in debuggers where wants just to refer to the
     ISO_EXTENSION_*_ names and get something.
@@ -597,7 +597,7 @@ extern enum iso_extension_enum_s {
 /** This is an opaque structure. */
 typedef struct _iso9660_s iso9660_t;
 
-  /*! Close previously opened ISO 9660 image and free resources
+  /** Close previously opened ISO 9660 image and free resources
     associated with the image. Call this when done using using an ISO
     9660 image.
 
@@ -610,7 +610,7 @@ typedef struct _iso9660_s iso9660_t;
   bool iso9660_close (iso9660_t * p_iso);
 
 
-  /*!
+  /**
     Open an ISO 9660 image for reading. Maybe in the future we will have
     a mode. NULL is returned on error.
 
@@ -622,7 +622,7 @@ typedef struct _iso9660_s iso9660_t;
   */
   iso9660_t *iso9660_open (const char *psz_path /*flags, mode */);
 
-  /*!
+  /**
     Open an ISO 9660 image for reading, allowing various ISO 9660
     extensions.  Maybe in the future we will have a mode. NULL is
     returned on error.
@@ -632,7 +632,7 @@ typedef struct _iso9660_s iso9660_t;
   iso9660_t *iso9660_open_ext (const char *psz_path,
                                iso_extension_mask_t iso_extension_mask);
 
-  /*! Open an ISO 9660 image for "fuzzy" reading. This means that we
+  /** Open an ISO 9660 image for "fuzzy" reading. This means that we
     will try to guess various internal offsets based on internal
     checks. This may be useful when trying to read an ISO 9660 image
     contained in a file format that libiso9660 doesn't know natively
@@ -649,7 +649,7 @@ typedef struct _iso9660_s iso9660_t;
   iso9660_t *iso9660_open_fuzzy (const char *psz_path /*flags, mode */,
                                  uint16_t i_fuzz);
 
-  /*!
+  /**
     Open an ISO 9660 image for reading with some tolerance for positioning
     of the ISO9660 image. We scan for ISO_STANDARD_ID and use that to set
     the eventual offset to adjust by (as long as that is <= i_fuzz).
@@ -663,7 +663,7 @@ typedef struct _iso9660_s iso9660_t;
                                      uint16_t i_fuzz
                                      /*flags, mode */);
 
-  /*!
+  /**
     Read the Super block of an ISO 9660 image but determine framesize
     and datastart and a possible additional offset. Generally here we are
     not reading an ISO 9660 image but a CD-Image which contains an ISO 9660
@@ -673,7 +673,7 @@ typedef struct _iso9660_s iso9660_t;
                                           iso_extension_mask_t iso_extension_mask,
                                           uint16_t i_fuzz);
 
-  /*!
+  /**
     Seek to a position and then read i_size blocks.
 
     @param p_iso the ISO-9660 file image to get data from
@@ -692,21 +692,21 @@ typedef struct _iso9660_s iso9660_t;
   long int iso9660_iso_seek_read (const iso9660_t *p_iso, /*out*/ void *ptr,
                                   lsn_t start, long int i_size);
 
-  /*!
+  /**
     Read the Primary Volume Descriptor for a CD.
     True is returned if read, and false if there was an error.
   */
   bool iso9660_fs_read_pvd ( const CdIo_t *p_cdio,
                              /*out*/ iso9660_pvd_t *p_pvd );
 
-  /*!
+  /**
     Read the Primary Volume Descriptor for an ISO 9660 image.
     True is returned if read, and false if there was an error.
   */
   bool iso9660_ifs_read_pvd (const iso9660_t *p_iso,
                              /*out*/ iso9660_pvd_t *p_pvd);
 
-  /*!
+  /**
     Read the Super block of an ISO 9660 image. This is the
     Primary Volume Descriptor (PVD) and perhaps a Supplemental Volume
     Descriptor if (Joliet) extensions are acceptable.
@@ -714,7 +714,7 @@ typedef struct _iso9660_s iso9660_t;
   bool iso9660_fs_read_superblock (CdIo_t *p_cdio,
                                    iso_extension_mask_t iso_extension_mask);
 
-  /*!
+  /**
     Read the Super block of an ISO 9660 image. This is the
     Primary Volume Descriptor (PVD) and perhaps a Supplemental Volume
     Descriptor if (Joliet) extensions are acceptable.
@@ -727,7 +727,7 @@ typedef struct _iso9660_s iso9660_t;
   Time conversion
  ====================================================*/
 
-  /*!
+  /**
     Set time in format used in ISO 9660 directory index record
     from a Unix time structure.
   */
@@ -735,7 +735,7 @@ typedef struct _iso9660_s iso9660_t;
                           /*out*/ iso9660_dtime_t *idr_date);
 
 
-  /*!
+  /**
     Set time in format used in ISO 9660 directory index record
     from a Unix time structure. timezone is given as an offset
     correction in minutes.
@@ -744,20 +744,20 @@ typedef struct _iso9660_s iso9660_t;
                                         int timezone,
                                         /*out*/ iso9660_dtime_t *p_idr_date);
 
-  /*!
+  /**
     Set "long" time in format used in ISO 9660 primary volume descriptor
     from a Unix time structure. */
   void iso9660_set_ltime (const struct tm *_tm,
                           /*out*/ iso9660_ltime_t *p_pvd_date);
 
-  /*!
+  /**
     Set "long" time in format used in ISO 9660 primary volume descriptor
     from a Unix time structure. */
   void iso9660_set_ltime_with_timezone (const struct tm *_tm,
                                         int timezone,
                                         /*out*/ iso9660_ltime_t *p_pvd_date);
 
-  /*!
+  /**
     Get Unix time structure from format use in an ISO 9660 directory index
     record. Even though tm_wday and tm_yday fields are not explicitly in
     idr_date, they are calculated from the other fields.
@@ -769,7 +769,7 @@ typedef struct _iso9660_s iso9660_t;
                           /*out*/ struct tm *p_tm);
 
 
-  /*!
+  /**
     Get "long" time in format used in ISO 9660 primary volume descriptor
     from a Unix time structure.
   */
@@ -779,21 +779,21 @@ typedef struct _iso9660_s iso9660_t;
   /*====================================================
     Character Classification and String Manipulation
     ====================================================*/
-  /*!
+  /**
     Return true if c is a DCHAR - a character that can appear in an an
     ISO-9600 level 1 directory name. These are the ASCII capital
     letters A-Z, the digits 0-9, and an underscore.
   */
   bool iso9660_is_dchar (int c);
 
-  /*!
+  /**
     Return true if c is an ACHAR -
     These are the DCHAR's plus some ASCII symbols, including the space
     symbol.
   */
   bool iso9660_is_achar (int c);
 
-  /*!
+  /**
     Convert an ISO-9660 file name, which is in the format usually stored
     in an ISO 9660 directory entry, into what's usually listed as the
     file name in a listing.  Lowercase name, and remove trailing ;1's
@@ -807,7 +807,7 @@ typedef struct _iso9660_s iso9660_t;
   int iso9660_name_translate(const char *psz_oldname,
                              /*out*/ char *psz_newname);
 
-  /*!
+  /**
     Convert an ISO-9660 file name, which is in the format usually stored
     in an ISO 9660 directory entry into what's usually listed as the
     file name in a listing.  Lowercase name if no Joliet Extension
@@ -825,7 +825,7 @@ typedef struct _iso9660_s iso9660_t;
   int iso9660_name_translate_ext(const char *psz_oldname, char *psz_newname,
                                  uint8_t i_joliet_level);
 
-  /*!
+  /**
     Pad string src with spaces to size len and copy this to dst. If
     len is less than the length of src, dst will be truncated to the
     first len characters of src.
@@ -843,7 +843,7 @@ typedef struct _iso9660_s iso9660_t;
     File and Directory Names
     ======================================================================*/
 
-  /*!
+  /**
     Check that psz_path is a valid ISO-9660 directory name.
 
     A valid directory name should not start out with a slash (/),
@@ -855,7 +855,7 @@ typedef struct _iso9660_s iso9660_t;
   */
   bool iso9660_dirname_valid_p (const char psz_path[]);
 
-  /*!
+  /**
     Take psz_path and a version number and turn that into a ISO-9660
     pathname.  (That's just the pathname followed by ";" and the version
     number. For example, mydir/file.ext -> MYDIR/FILE.EXT;1 for version
@@ -863,7 +863,7 @@ typedef struct _iso9660_s iso9660_t;
   */
   char *iso9660_pathname_isofy (const char psz_path[], uint16_t i_version);
 
-  /*!
+  /**
     Check that psz_path is a valid ISO-9660 pathname.
 
     A valid pathname contains a valid directory name, if one appears and
@@ -901,7 +901,7 @@ iso9660_dir_add_entry_su (void *dir, const char filename[], uint32_t extent,
 unsigned int
 iso9660_dir_calc_record_size (unsigned int namelen, unsigned int su_len);
 
-/*!
+/**
    Given a directory pointer, find the filesystem entry that contains
    lsn and return information about it.
 
@@ -915,7 +915,7 @@ iso9660_stat_t *iso9660_fs_find_lsn(CdIo_t *p_cdio, lsn_t i_lsn);
 iso9660_stat_t *iso9660_find_fs_lsn(CdIo_t *p_cdio, lsn_t i_lsn);
 
 
-/*!
+/**
    Given a directory pointer, find the filesystem entry that contains
    LSN and return information about it.
 
@@ -934,7 +934,7 @@ iso9660_stat_t *iso9660_find_fs_lsn(CdIo_t *p_cdio, lsn_t i_lsn);
 iso9660_stat_t *iso9660_fs_find_lsn_with_path(CdIo_t *p_cdio, lsn_t i_lsn,
                                               /*out*/ char **ppsz_full_filename);
 
-/*!
+/**
    Given a directory pointer, find the filesystem entry that contains
    lsn and return information about it.
 
@@ -948,7 +948,7 @@ iso9660_stat_t *iso9660_fs_find_lsn_with_path(CdIo_t *p_cdio, lsn_t i_lsn,
 iso9660_stat_t *iso9660_ifs_find_lsn(iso9660_t *p_iso, lsn_t i_lsn);
 
 
-/*!
+/**
    Given a directory pointer, find the filesystem entry that contains
    lsn and return information about it.
 
@@ -968,7 +968,7 @@ iso9660_stat_t *iso9660_ifs_find_lsn_with_path(iso9660_t *p_iso,
                                                lsn_t i_lsn,
                                                /*out*/ char **ppsz_path);
 
-/*!
+/**
   Free the passed iso9660_stat_t structure.
 
   @param p_stat iso9660 stat buffer to free.
@@ -976,7 +976,7 @@ iso9660_stat_t *iso9660_ifs_find_lsn_with_path(iso9660_t *p_iso,
  */
 void iso9660_stat_free(iso9660_stat_t *p_stat);
 
-/*!
+/**
   Return file status for psz_path. NULL is returned on error.
 
   @param p_cdio the CD object to read from
@@ -999,7 +999,7 @@ void iso9660_stat_free(iso9660_stat_t *p_stat);
 iso9660_stat_t *iso9660_fs_stat (CdIo_t *p_cdio, const char psz_path[]);
 
 
-/*!
+/**
   Return file status for path name psz_path. NULL is returned on error.
   pathname version numbers in the ISO 9660 name are dropped, i.e. ;1
   is removed and if level 1 ISO-9660 names are lowercased.
@@ -1014,7 +1014,7 @@ iso9660_stat_t *iso9660_fs_stat (CdIo_t *p_cdio, const char psz_path[]);
  */
 iso9660_stat_t *iso9660_fs_stat_translate (CdIo_t *p_cdio,
                                            const char psz_path[]);
-/*!
+/**
 
   @param p_iso the ISO-9660 file image to get data from
 
@@ -1026,7 +1026,7 @@ iso9660_stat_t *iso9660_fs_stat_translate (CdIo_t *p_cdio,
 iso9660_stat_t *iso9660_ifs_stat (iso9660_t *p_iso, const char psz_path[]);
 
 
-/*!
+/**
   @param p_iso the ISO-9660 file image to get data from
 
   @param psz_path filename path translate
@@ -1040,7 +1040,7 @@ iso9660_stat_t *iso9660_ifs_stat_translate (iso9660_t *p_iso,
                                             const char psz_path[]);
 
 
-/*!
+/**
   Create a new data structure to hold a list of
   ISO9660 statbuf-entry pointers for the files inside
   a directory.
@@ -1050,7 +1050,7 @@ iso9660_stat_t *iso9660_ifs_stat_translate (iso9660_t *p_iso,
 CdioISO9660FileList_t * iso9660_filelist_new(void);
 
 
-/*!
+/**
   Create a new data structure to hold a list of
   ISO9660 statbuf entries for directory
   pointers for the files inside a directory.
@@ -1061,19 +1061,19 @@ CdioISO9660DirList_t * iso9660_dirlist_new(void);
 
 
 
-/*!
+/**
   Free the passed CdioISOC9660FileList_t structure.
 */
 void iso9660_filelist_free(CdioISO9660FileList_t *p_filelist);
 
 
-/*!
+/**
   Free the passed CdioISOC9660Dirlist_t structure.
 */
 void iso9660_dirlist_free(CdioISO9660DirList_t *p_filelist);
 
 
-/*!
+/**
   Read psz_path (a directory) and return a list of iso9660_stat_t
   pointers for the files inside that directory.
 
@@ -1086,7 +1086,7 @@ void iso9660_dirlist_free(CdioISO9660DirList_t *p_filelist);
 */
 CdioList_t * iso9660_fs_readdir (CdIo_t *p_cdio, const char psz_path[]);
 
-/*!
+/**
   Read psz_path (a directory) and return a list of iso9660_stat_t
   pointers for the files inside that directory.
 
@@ -1099,7 +1099,7 @@ CdioList_t * iso9660_fs_readdir (CdIo_t *p_cdio, const char psz_path[]);
 */
 CdioList_t * iso9660_ifs_readdir (iso9660_t *p_iso, const char psz_path[]);
 
-/*!
+/**
   Return the PVD's application ID.
 
   @param p_pvd the PVD to get data from
@@ -1111,7 +1111,7 @@ CdioList_t * iso9660_ifs_readdir (iso9660_t *p_iso, const char psz_path[]);
 */
 char * iso9660_get_application_id(iso9660_pvd_t *p_pvd);
 
-/*!
+/**
   Return the PVD's application ID.
 
   @param p_iso the ISO-9660 file image to get data from
@@ -1125,7 +1125,7 @@ char * iso9660_get_application_id(iso9660_pvd_t *p_pvd);
 bool iso9660_ifs_get_application_id(iso9660_t *p_iso,
                                     /*out*/ cdio_utf8_t **p_psz_app_id);
 
-/*!
+/**
   Return the Joliet level recognized for p_iso.
 */
 uint8_t iso9660_ifs_get_joliet_level(iso9660_t *p_iso);
@@ -1138,7 +1138,7 @@ uint8_t iso9660_get_dir_size(const iso9660_dir_t *p_idr);
 lsn_t iso9660_get_dir_extent(const iso9660_dir_t *p_idr);
 #endif
 
-  /*!
+  /**
     Return the directory name stored in the iso9660_dir_t
 
     A string is allocated: the caller must deallocate. This routine
@@ -1146,31 +1146,31 @@ lsn_t iso9660_get_dir_extent(const iso9660_dir_t *p_idr);
   */
   char * iso9660_dir_to_name (const iso9660_dir_t *p_iso9660_dir);
 
-  /*!
+  /**
     Returns a POSIX mode for a given p_iso_dirent.
   */
   mode_t iso9660_get_posix_filemode(const iso9660_stat_t *p_iso_dirent);
 
-  /*!
+  /**
     Return a string containing the preparer id with trailing
     blanks removed.
   */
   char *iso9660_get_preparer_id(const iso9660_pvd_t *p_pvd);
 
-  /*!
+  /**
     Get the preparer ID.  psz_preparer_id is set to NULL if there
     is some problem in getting this and false is returned.
   */
   bool iso9660_ifs_get_preparer_id(iso9660_t *p_iso,
                                    /*out*/ cdio_utf8_t **p_psz_preparer_id);
 
-  /*!
+  /**
     Return a string containing the PVD's publisher id with trailing
     blanks removed.
   */
   char *iso9660_get_publisher_id(const iso9660_pvd_t *p_pvd);
 
-  /*!
+  /**
     Get the publisher ID.  psz_publisher_id is set to NULL if there
     is some problem in getting this and false is returned.
   */
@@ -1185,18 +1185,18 @@ lsn_t iso9660_get_dir_extent(const iso9660_dir_t *p_idr);
 
   int iso9660_get_pvd_block_size(const iso9660_pvd_t *p_pvd) ;
 
-  /*! Return the primary volume id version number (of pvd).
+  /** Return the primary volume id version number (of pvd).
     If there is an error 0 is returned.
   */
   int iso9660_get_pvd_version(const iso9660_pvd_t *pvd) ;
 
-  /*!
+  /**
     Return a string containing the PVD's system id with trailing
     blanks removed.
   */
   char *iso9660_get_system_id(const iso9660_pvd_t *p_pvd);
 
-  /*!
+  /**
     Return "yup" if any file has Rock-Ridge extensions. Warning: this can
     be time consuming. On an ISO 9600 image with lots of files but no Rock-Ridge
     extensions, the entire directory structure will be scanned up to u_file_limit.
@@ -1212,7 +1212,7 @@ lsn_t iso9660_get_dir_extent(const iso9660_dir_t *p_idr);
   */
   bool_3way_t iso9660_have_rr(iso9660_t *p_iso, uint64_t u_file_limit);
 
-  /*!
+  /**
     Get the system ID.  psz_system_id is set to NULL if there
     is some problem in getting this, and false is returned.
   */
@@ -1220,31 +1220,31 @@ lsn_t iso9660_get_dir_extent(const iso9660_dir_t *p_idr);
                                  /*out*/ cdio_utf8_t **p_psz_system_id);
 
 
-  /*! Return the LSN of the root directory for pvd.
+  /** Return the LSN of the root directory for pvd.
     If there is an error, CDIO_INVALID_LSN is returned.
   */
   lsn_t iso9660_get_root_lsn(const iso9660_pvd_t *p_pvd);
 
-  /*!
+  /**
     Get the volume ID in the PVD.  psz_volume_id is set to NULL if there
     is some problem in getting this, and false is returned.
   */
   char *iso9660_get_volume_id(const iso9660_pvd_t *p_pvd);
 
-  /*!
+  /**
     Get the volume ID in the PVD.  psz_volume_id is set to NULL if there
     is some problem in getting this, and false is returned.
   */
   bool iso9660_ifs_get_volume_id(iso9660_t *p_iso,
                                  /*out*/ cdio_utf8_t **p_psz_volume_id);
 
-  /*!
+  /**
     Return the volumeset ID in the PVD.
     NULL is returned if there is a problem in getting this.
   */
   char *iso9660_get_volumeset_id(const iso9660_pvd_t *p_pvd);
 
-  /*!
+  /**
     Get the volumeset ID.  psz_systemset_id is set to NULL if there
     is some problem in getting this, and false is returned.
   */
@@ -1253,7 +1253,7 @@ lsn_t iso9660_get_dir_extent(const iso9660_dir_t *p_idr);
 
   /* pathtable */
 
-  /*! Zero's out pathable. Do this first. */
+  /** Zero's out pathable. Do this first. */
   void iso9660_pathtable_init (void *pt);
 
   unsigned int iso9660_pathtable_get_size (const void *pt);
@@ -1278,7 +1278,7 @@ lsn_t iso9660_get_dir_extent(const iso9660_dir_t *p_idr);
 
   void iso9660_set_evd (void *pd);
 
-  /*!
+  /**
     Return true if the ISO 9660 image has extended attributes (XA).
   */
   bool iso9660_ifs_is_xa (const iso9660_t * p_iso);

--- a/include/cdio/memory.h
+++ b/include/cdio/memory.h
@@ -1,4 +1,4 @@
-/*  
+/*
     Copyright (C) 2014 Robert Kausch <robert.kausch@freac.org>
 
     This program is free software: you can redistribute it and/or modify
@@ -15,8 +15,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/*!
- * \file memory.h 
+/**
+ * \file memory.h
  *
  * \brief memory management utility functions.
  *
@@ -29,7 +29,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-  /*!
+  /**
     Free the passed pointer.
   */
   void cdio_free(void *p_memory);

--- a/include/cdio/mmc.h
+++ b/include/cdio/mmc.h
@@ -30,7 +30,7 @@
    We will use the MMC-6 draft 2g circa 2009 described in
    https://www.13thmonkey.org/documentation/SCSI/mmc6r02g.pdf
 
-   For a SPCS-3 we use the draft found at:
+   For SPC-3, we use the draft found at:
    https://www.13thmonkey.org/documentation/SCSI/spc3r23.pdf
 */
 

--- a/include/cdio/mmc.h
+++ b/include/cdio/mmc.h
@@ -25,12 +25,13 @@
    The documents we make use of are described in several
    specifications made by the SCSI committee T10
    http://www.t10.org. In particular, SCSI Primary Commands (SPC),
-   SCSI Block Commands (SBC), and Multi-Media Commands (MMC). These
-   documents generally have a numeric level number appended. For
-   example SPC-3 refers to ``SCSI Primary Commands - 3'.
+   SCSI Block Commands (SBC), and Multi-Media Commands (MMC).
 
-   In year 2010 the current versions were SPC-3, SBC-2, MMC-5.
+   We will use the MMC-6 draft 2g circa 2009 described in
+   https://www.13thmonkey.org/documentation/SCSI/mmc6r02g.pdf
 
+   For a SPCS-3 we use the draft found at:
+   https://www.13thmonkey.org/documentation/SCSI/spc3r23.pdf
 */
 
 #ifndef CDIO_MMC_H_
@@ -157,13 +158,13 @@ extern "C" {
   /**
       Group 2 Commands (CDB's here are 10-bytes)
   */
-  CDIO_MMC_GPCMD_READ_FORMAT_CAPACITIES = 0x23, /**< MMC-5 Section 6.24 */
-  CDIO_MMC_GPCMD_READ_CAPACITIY         = 0x25, /**< MMC-5 Section 6.19 */
+  CDIO_MMC_GPCMD_READ_FORMAT_CAPACITIES = 0x23, /**< MMC-6 Section 6.23 READ FORMAT CAPABILITIES Command */
+  CDIO_MMC_GPCMD_READ_CAPACITIY         = 0x25, /**< MMC-6 2g Section 6.18 READ CAPACITY Command */
   CDIO_MMC_GPCMD_READ_10                = 0x28, /**< Read data from drive
                                                    (10 bytes). */
   CDIO_MMC_GPCMD_WRITE_10               = 0x2a,
   CDIO_MMC_GPCMD_SEEK_10                = 0x2b,
-  CDIO_MMC_GPCMD_ERASE_10               = 0x2c, /**< MMC5 Section 6.4 */
+  CDIO_MMC_GPCMD_ERASE_10               = 0x2c, /**< MMC5 Section 6.4; Removed from MMC6 */
   CDIO_MMC_GPCMD_WRITE_AND_VERIFY_10    = 0x2e,
   CDIO_MMC_GPCMD_VERIFY_10              = 0x2f,
   CDIO_MMC_GPCMD_SYNCHRONIZE_CACHE      = 0x35,
@@ -237,7 +238,7 @@ extern "C" {
                                                    handled by Plextor drives.
                                                 */
   CDIO_MMC_GPCMD_WRITE_12               = 0xaa,
-  CDIO_MMC_GPCMD_READ_MEDIA_SERIAL_12   = 0xab, /**< MMC-5 Section 6.25 */
+  CDIO_MMC_GPCMD_READ_MEDIA_SERIAL_12   = 0xab, /**< MMC-6 2g Section 6.24 READ MEDIA SERIAL NUMBER Command */
   CDIO_MMC_GPCMD_GET_PERFORMANCE        = 0xac,
   CDIO_MMC_GPCMD_READ_DVD_STRUCTURE     = 0xad, /**< Get DVD structure info
                                                    from media (12 bytes). */

--- a/include/cdio/mmc_ll_cmds.h
+++ b/include/cdio/mmc_ll_cmds.h
@@ -1,6 +1,7 @@
 /*
     Copyright (C) 2018 Thomas Schmitt
-    Copyright (C) 2010, 2012, 2016, 2019, 2025 Rocky Bernstein <rocky@gnu.org>
+    Copyright (C) 2010, 2012, 2016, 2019, 2025, 2026 Rocky Bernstein
+   <rocky@gnu.org>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -19,18 +20,17 @@
 /**
    \file mmc_ll_cmds.h
 
-   \brief Wrappers for specific Multimedia Command (MMC) commands e.g., READ
-   DISC, START/STOP UNIT.
+   \brief Wrappers for specific Multimedia Command (MMC) commands e.g., \p READ
+   \p DISC, \p START/STOP \p UNIT.
 
    The documents we make use of are described in several
    specifications made by the SCSI committee T10
    http://www.t10.org. In particular, SCSI Primary Commands (SPC),
-   SCSI Block Commands (SBC), and Multi-Media Commands (MMC). These
-   documents generally have a numeric level number appended. For
-   example SPC-3 refers to ``SCSI Primary Commands - 3'.
+   SCSI Block Commands (SBC), and Multi-Media Commands (MMC).
 
-   In year 2010 the current versions were SPC-3, SBC-2, MMC-5.
-
+   The documents we make use of are described Multi-Media Commands
+   (MMC). We will use the MMC-6 draft 2g circa 2009 described in
+   https://www.13thmonkey.org/documentation/SCSI/mmc6r02g.pdf
 */
 
 #ifndef CDIO_MMC_LL_CMDS_H_
@@ -42,325 +42,319 @@
 extern "C" {
 #endif /* __cplusplus */
 
-  /**
-     Get drive capabilities via SCSI-MMC \p GET \p CONFIGURATION
-     @param p_cdio the CD object to be acted upon.
+/**
+   Get drive capabilities via SCSI-MMC \p GET \p CONFIGURATION
+   @param p_cdio the CD object to be acted upon.
 
-     @param p_buf pointer to location to store mode sense information
+   @param p_buf pointer to location to store mode sense information
 
-     @param i_size number of bytes allocated to p_buf
+   @param i_size number of bytes allocated to p_buf
 
-     @param i_return_type value in range 0..2 giving what kind of configuration
-     to return:
+   @param i_return_type value in range 0..2 giving what kind of configuration
+   to return:
 
-     - 0 &mdash; Full Header and Full Descriptors;
-     - 1 &mdash; Feature Headers and those with their Current Bit.
-     - 2 &mdash; One Feature header and zero or one Feature Descriptors.
+   - 0 &mdash; Full Header and Full Descriptors;
+   - 1 &mdash; Feature Headers and those with their Current Bit.
+   - 2 &mdash; One Feature header and zero or one Feature Descriptors.
 
-     @param i_starting_feature_number feature number from which to start
-     getting information.
+   @param i_starting_feature_number feature number from which to start
+   getting information.
 
-     @param i_timeout_ms value in milliseconds to use on timeout. Setting
-     to 0 uses the default time-out value stored in
-     mmc_timeout_ms.
+   @param i_timeout_ms value in milliseconds to use on timeout. Setting
+   to 0 uses the default time-out value stored in
+   mmc_timeout_ms.
 
-     @return \p DRIVER_OP_SUCCESS (0) if we got the status.
-     return codes are the same as \p driver_return_code_t
-  */
-    driver_return_code_t
-    mmc_get_configuration(const CdIo_t *p_cdio, void *p_buf,
-                          unsigned int i_size,
-                          unsigned int i_return_type,
-                          unsigned int i_starting_feature_number,
-                          unsigned int i_timeout_ms);
+   @return \p DRIVER_OP_SUCCESS (0) if we got the status.
+   return codes are the same as \p driver_return_code_t
+*/
+driver_return_code_t
+mmc_get_configuration(const CdIo_t *p_cdio, void *p_buf, unsigned int i_size,
+                      unsigned int i_return_type,
+                      unsigned int i_starting_feature_number,
+                      unsigned int i_timeout_ms);
 
-  /**
-    Return results of media event status via SCSI-MMC \p GET \p EVENT \p STATUS
+/**
+  Return results of media event status via SCSI-MMC \p GET \p EVENT \p STATUS
 
+  @param p_cdio the CD object to be acted upon.
+
+  @param out_buf media status code from operation
+
+  @return \p DRIVER_OP_SUCCESS (0) if we got the status. Return codes
+  are the same as \p driver_return_code_t
+ */
+driver_return_code_t mmc_get_event_status(const CdIo_t *p_cdio,
+                                          uint8_t out_buf[2]);
+
+/**
+   Run a SCSI-MMC \p MODE \p SELECT (10-byte) command
+   and put the results in \p p_buf.
+
+   @param p_cdio the CD object to be acted upon.
+
+   @param p_buf pointer to location to store mode sense information
+
+   @param i_size number of bytes allocated to p_buf
+
+   @param page which "page" of the mode sense command we are interested in
+
+   @param i_timeout_ms value in milliseconds to use on timeout. Setting
+          to 0 uses the default time-out value stored in
+          mmc_timeout_ms.
+
+   @return \p DRIVER_OP_SUCCESS if we ran the command ok.
+*/
+driver_return_code_t mmc_mode_select_10(CdIo_t *p_cdio, /*out*/ void *p_buf,
+                                        unsigned int i_size, int page,
+                                        unsigned int i_timeout_ms);
+/**
+   Run a SCSI-MMC \p MODE \p SENSE command (10-byte version)
+   and put the results in \p p_buf.
+   @param p_cdio the CD object to be acted upon.
+   @param p_buf pointer to location to store mode sense information
+
+   @param i_size number of bytes allocated to p_buf
+
+   @param i_page_code which "page" of the mode sense command we are
+   interested in
+
+   @return \p DRIVER_OP_SUCCESS if we ran the command ok.
+*/
+driver_return_code_t mmc_mode_sense_10(CdIo_t *p_cdio, /*out*/ void *p_buf,
+                                       unsigned int i_size,
+                                       unsigned int i_page_code);
+
+/**
+    Run a SCSI-MMC \p MODE \p SENSE command (6-byte version)
+    and put the results in \p p_buf.
     @param p_cdio the CD object to be acted upon.
-
-    @param out_buf media status code from operation
-
-    @return \p DRIVER_OP_SUCCESS (0) if we got the status. Return codes
-    are the same as \p driver_return_code_t
-   */
-  driver_return_code_t mmc_get_event_status(const CdIo_t *p_cdio,
-                                            uint8_t out_buf[2]);
-
-
-   /**
-      Run a SCSI-MMC \p MODE \p SELECT (10-byte) command
-      and put the results in \p p_buf.
-
-      @param p_cdio the CD object to be acted upon.
-
-      @param p_buf pointer to location to store mode sense information
-
-      @param i_size number of bytes allocated to p_buf
-
-      @param page which "page" of the mode sense command we are interested in
-
-      @param i_timeout_ms value in milliseconds to use on timeout. Setting
-             to 0 uses the default time-out value stored in
-             mmc_timeout_ms.
-
-      @return \p DRIVER_OP_SUCCESS if we ran the command ok.
-   */
-  driver_return_code_t mmc_mode_select_10(CdIo_t *p_cdio, /*out*/ void *p_buf,
-                                          unsigned int i_size, int page,
-                                          unsigned int i_timeout_ms);
-  /**
-     Run a SCSI-MMC \p MODE \p SENSE command (10-byte version)
-     and put the results in \p p_buf.
-     @param p_cdio the CD object to be acted upon.
-     @param p_buf pointer to location to store mode sense information
-
-     @param i_size number of bytes allocated to p_buf
-
-     @param i_page_code which "page" of the mode sense command we are
-     interested in
-
-     @return \p DRIVER_OP_SUCCESS if we ran the command ok.
-  */
-  driver_return_code_t mmc_mode_sense_10( CdIo_t *p_cdio, /*out*/ void *p_buf,
-                                          unsigned int i_size,
-                                          unsigned int i_page_code);
-
-  /**
-      Run a SCSI-MMC \p MODE \p SENSE command (6-byte version)
-      and put the results in \p p_buf.
-      @param p_cdio the CD object to be acted upon.
-      @param p_buf pointer to location to store mode sense information
-      @param i_size number of bytes allocated to p_buf
-      @param page which "page" of the mode sense command we are interested in
-      @return \p DRIVER_OP_SUCCESS if we ran the command ok.
-  */
-  driver_return_code_t  mmc_mode_sense_6( CdIo_t *p_cdio, /*out*/ void *p_buf,
-                                          unsigned int i_size, int page);
-
-  /**
-     Request preventing/allowing medium removal on a drive via
-     SCSI-MMC \p PREVENT/ALLOW \p MEDIUM \p REMOVAL.
-
-     @param p_cdio the CD object to be acted upon.
-     @param b_persistent make b_prevent state persistent
-     @param b_prevent true of drive locked and false if unlocked
-
-     @param i_timeout_ms value in milliseconds to use on timeout. Setting
-            to 0 uses the default time-out value stored in
-            mmc_timeout_ms.
-
-     @return \p DRIVER_OP_SUCCESS (0) if we got the status.
-     return codes are the same as \p driver_return_code_t
-  */
-    driver_return_code_t
-    mmc_prevent_allow_medium_removal(const CdIo_t *p_cdio,
-                                     bool b_persistent, bool b_prevent,
-                                     unsigned int i_timeout_ms);
-
-  /**
-      Issue a MMC READ_CD command.
-
-      @param p_cdio object to read from
-
-      @param p_buf  Place to store data. The caller should ensure that
-      \p p_buf can hold at least \p i_blocksize * \p i_blocks  bytes.
-
-      @param i_lsn  sector to read
-
-      @param expected_sector_type restricts reading to a specific CD
-      sector type.  Only 3 bits with values 1-5 are used:
-      - 0 &mdash; all sector types
-      - 1 &mdash; CD-DA sectors only
-      - 2 &mdash; Mode 1 sectors only
-      - 3 &mdash; Mode 2 formless sectors only. Note in contrast to all other
-      values an MMC CD-ROM is not required to support this mode.
-      - 4 &mdash; Mode 2 Form 1 sectors only
-      - 5 &mdash; Mode 2 Form 2 sectors only
-
-    @param b_digital_audio_play Control error concealment when the
-    data being read is CD-DA.  If the data being read is not CD-DA,
-    this parameter is ignored.  If the data being read is CD-DA and
-    DAP is false zero, then the user data returned should not be
-    modified by flaw obscuring mechanisms such as audio data mute and
-    interpolate.  If the data being read is CD-DA and DAP is true,
-    then the user data returned should be modified by flaw obscuring
-    mechanisms such as audio data mute and interpolate.
-
-    b_sync_header return the sync header (which will probably have
-    the same value as \p CDIO_SECTOR_SYNC_HEADER of size
-    \p CDIO_CD_SYNC_SIZE).
-
-    @param header_codes Header Codes refer to the sector header and
-    the sub-header that is present in mode 2 formed sectors:
-
-    - 0 &mdash; No header information is returned.
-    - 1 &mdash;  The 4-byte sector header of data sectors is be returned,
-    - 2 &mdash; The 8-byte sector sub-header of mode 2 formed sectors is
-    returned.
-    - 3 &mdash Both sector header and sub-header (12 bytes) is returned.
-
-    The Header precedes the rest of the bytes (e.g. user-data bytes)
-    that might get returned.
-
-    @param b_user_data  Return user data if true.
-
-    For CD-DA, the User Data is \p CDIO_CD_FRAMESIZE_RAW bytes.
-
-    For Mode 1, The User Data is \p ISO_BLOCKSIZE bytes beginning at
-    offset \p CDIO_CD_HEADER_SIZE+CDIO_CD_SUBHEADER_SIZE.
-
-    For Mode 2 formless, The User Data is M2RAW_SECTOR_SIZE bytes
-    beginning at offset \p CDIO_CD_HEADER_SIZE+CDIO_CD_SUBHEADER_SIZE.
-
-    For data Mode 2, form 1, User Data is ISO_BLOCKSIZE bytes beginning at
-    offset \p CDIO_CD_XA_SYNC_HEADER.
-
-    For data Mode 2, form 2, User Data is 2 groups of 324 bytes beginning at
-    offset \p CDIO_CD_XA_SYNC_HEADER.
-
-    @param b_sync
-
-    @param b_edc_ecc true if we return EDC/ECC error detection/correction bits.
-
-    The presence and size of EDC redundancy or ECC parity is defined
-    according to sector type:
-
-    CD-DA sectors have neither EDC redundancy nor ECC parity.
-
-    Data Mode 1 sectors have 288 bytes of EDC redundancy, Pad, and
-    ECC parity beginning at offset 2064.
-
-    Data Mode 2 formless sectors have neither EDC redundancy nor ECC
-    parity
-
-    Data Mode 2 form 1 sectors have 280 bytes of EDC redundancy and
-    ECC parity beginning at offset 2072
-
-    Data Mode 2 form 2 sectors optionally have 4 bytes of EDC
-    redundancy beginning at offset 2348.
-
-
-    @param c2_error_information If true associate a bit with each
-    sector for C2 error The resulting bit field is ordered exactly as
-    the main channel bytes.  Each 8-bit boundary defines a byte of
-    flag bits.
-
-    @param subchannel_selection subchannel-selection bits
-
-    - 0 &mdash; No Sub-channel data shall be returned.  (0 bytes)
-    - 1 &mdash;  RAW P-W Sub-channel data shall be returned.  (96 byte)
-    - 2 &mdash;  Formatted Q sub-channel data shall be transferred (16 bytes)
-    - 3 &mdash; Reserved
-    - 4 &mdash;  Corrected and de-interleaved R-W sub-channel (96 bytes)
-    - 5-7 &mdash; Reserved
-
-    @param i_blocksize size of the a block expected to be returned
-
-    @param i_blocks number of blocks expected to be returned.
-
+    @param p_buf pointer to location to store mode sense information
+    @param i_size number of bytes allocated to p_buf
+    @param page which "page" of the mode sense command we are interested in
     @return \p DRIVER_OP_SUCCESS if we ran the command ok.
-  */
-  driver_return_code_t
-  mmc_read_cd(const CdIo_t *p_cdio, void *p_buf, lsn_t i_lsn,
-              int expected_sector_type, bool b_digital_audio_play,
-              bool b_sync, uint8_t header_codes, bool b_user_data,
-              bool b_edc_ecc, uint8_t c2_error_information,
-              uint8_t subchannel_selection, uint16_t i_blocksize,
-              uint32_t i_blocks);
+*/
+driver_return_code_t mmc_mode_sense_6(CdIo_t *p_cdio, /*out*/ void *p_buf,
+                                      unsigned int i_size, int page);
 
-  /**
-     Request information about et drive capabilities via SCSI-MMC READ
-     DISC INFORMATION
+/**
+   Request preventing/allowing medium removal on a drive via
+   SCSI-MMC \p PREVENT/ALLOW \p MEDIUM \p REMOVAL.
 
-     @param p_cdio the CD object to be acted upon.
+   @param p_cdio the CD object to be acted upon.
+   @param b_persistent make b_prevent state persistent
+   @param b_prevent true of drive locked and false if unlocked
 
-     @param p_buf pointer to location to store mode sense information
+   @param i_timeout_ms value in milliseconds to use on timeout. Setting
+          to 0 uses the default time-out value stored in
+          mmc_timeout_ms.
 
-     @param i_size number of bytes allocated to p_buf
+   @return \p DRIVER_OP_SUCCESS (0) if we got the status.
+   return codes are the same as \p driver_return_code_t
+*/
+driver_return_code_t
+mmc_prevent_allow_medium_removal(const CdIo_t *p_cdio, bool b_persistent,
+                                 bool b_prevent, unsigned int i_timeout_ms);
 
-     @param data_type kind of information to retrieve.
+/**
+    Issue a MMC READ_CD command.
 
-     @param i_timeout_ms value in milliseconds to use on timeout. Setting
-     to 0 uses the default time-out value stored in
-     mmc_timeout_ms.
+    @param p_cdio object to read from
 
-     @return DRIVER_OP_SUCCESS (0) if we got the status.
-  */
- driver_return_code_t
- mmc_read_disc_information(const CdIo_t *p_cdio, /*out*/ void *p_buf,
-                           unsigned int i_size,
-                           cdio_mmc_read_disc_info_datatype_t data_type,
-                           unsigned int i_timeout_ms);
+    @param p_buf  Place to store data. The caller should ensure that
+    \p p_buf can hold at least \p i_blocksize * \p i_blocks  bytes.
 
-  /**
-    Set the drive speed in K bytes per second using SCSI-MMC SET SPEED.
+    @param i_lsn  sector to read
+
+    @param expected_sector_type restricts reading to a specific CD
+    sector type.  Only 3 bits with values 1-5 are used:
+    - 0 &mdash; all sector types
+    - 1 &mdash; CD-DA sectors only
+    - 2 &mdash; Mode 1 sectors only
+    - 3 &mdash; Mode 2 formless sectors only. Note in contrast to all other
+    values an MMC CD-ROM is not required to support this mode.
+    - 4 &mdash; Mode 2 Form 1 sectors only
+    - 5 &mdash; Mode 2 Form 2 sectors only
+
+  @param b_digital_audio_play Control error concealment when the
+  data being read is CD-DA.  If the data being read is not CD-DA,
+  this parameter is ignored.  If the data being read is CD-DA and
+  DAP is false zero, then the user data returned should not be
+  modified by flaw obscuring mechanisms such as audio data mute and
+  interpolate.  If the data being read is CD-DA and DAP is true,
+  then the user data returned should be modified by flaw obscuring
+  mechanisms such as audio data mute and interpolate.
+
+  b_sync_header return the sync header (which will probably have
+  the same value as \p CDIO_SECTOR_SYNC_HEADER of size
+  \p CDIO_CD_SYNC_SIZE).
+
+  @param header_codes Header Codes refer to the sector header and
+  the sub-header that is present in mode 2 formed sectors:
+
+  - 0 &mdash; No header information is returned.
+  - 1 &mdash;  The 4-byte sector header of data sectors is be returned,
+  - 2 &mdash; The 8-byte sector sub-header of mode 2 formed sectors is
+  returned.
+  - 3 &mdash Both sector header and sub-header (12 bytes) is returned.
+
+  The Header precedes the rest of the bytes (e.g. user-data bytes)
+  that might get returned.
+
+  @param b_user_data  Return user data if true.
+
+  For CD-DA, the User Data is \p CDIO_CD_FRAMESIZE_RAW bytes.
+
+  For Mode 1, The User Data is \p ISO_BLOCKSIZE bytes beginning at
+  offset \p CDIO_CD_HEADER_SIZE+CDIO_CD_SUBHEADER_SIZE.
+
+  For Mode 2 formless, The User Data is M2RAW_SECTOR_SIZE bytes
+  beginning at offset \p CDIO_CD_HEADER_SIZE+CDIO_CD_SUBHEADER_SIZE.
+
+  For data Mode 2, form 1, User Data is ISO_BLOCKSIZE bytes beginning at
+  offset \p CDIO_CD_XA_SYNC_HEADER.
+
+  For data Mode 2, form 2, User Data is 2 groups of 324 bytes beginning at
+  offset \p CDIO_CD_XA_SYNC_HEADER.
+
+  @param b_sync
+
+  @param b_edc_ecc true if we return EDC/ECC error detection/correction bits.
+
+  The presence and size of EDC redundancy or ECC parity is defined
+  according to sector type:
+
+  CD-DA sectors have neither EDC redundancy nor ECC parity.
+
+  Data Mode 1 sectors have 288 bytes of EDC redundancy, Pad, and
+  ECC parity beginning at offset 2064.
+
+  Data Mode 2 formless sectors have neither EDC redundancy nor ECC
+  parity
+
+  Data Mode 2 form 1 sectors have 280 bytes of EDC redundancy and
+  ECC parity beginning at offset 2072
+
+  Data Mode 2 form 2 sectors optionally have 4 bytes of EDC
+  redundancy beginning at offset 2348.
 
 
-    @param p_cdio        CD structure set by cdio_open().
-    @param i_Kbs_speed   speed in K bytes per second. Note this is
-                         not in standard CD-ROM speed units, e.g.
-                         1x, 4x, 16x as it is in cdio_set_speed.
-                         To convert CD-ROM speed units to Kbs,
-                         multiply the number by 176 (for raw data)
-                         and by 150 (for filesystem data).
-                         Also note that ATAPI specs say that a value
-                         less than 176 will result in an error.
-                         On many CD-ROM drives,
-                         specifying a value too large will result in using
-                         the fastest speed.
+  @param c2_error_information If true associate a bit with each
+  sector for C2 error The resulting bit field is ordered exactly as
+  the main channel bytes.  Each 8-bit boundary defines a byte of
+  flag bits.
 
-    @param i_timeout_ms value in milliseconds to use on timeout. Setting
-           to 0 uses the default time-out value stored in
-           mmc_timeout_ms.
+  @param subchannel_selection subchannel-selection bits
 
-    @return the drive speed if greater than 0. -1 if we had an error. is -2
-    returned if this is not implemented for the current driver.
+  - 0 &mdash; No Sub-channel data shall be returned.  (0 bytes)
+  - 1 &mdash;  RAW P-W Sub-channel data shall be returned.  (96 byte)
+  - 2 &mdash;  Formatted Q sub-channel data shall be transferred (16 bytes)
+  - 3 &mdash; Reserved
+  - 4 &mdash;  Corrected and de-interleaved R-W sub-channel (96 bytes)
+  - 5-7 &mdash; Reserved
 
-    @see cdio_set_speed and mmc_set_drive_speed
-  */
-  driver_return_code_t mmc_set_speed( const CdIo_t *p_cdio,
-                                      int i_Kbs_speed,
-                                      unsigned int i_timeout_ms);
+  @param i_blocksize size of the a block expected to be returned
 
-  /**
-    Load or Unload media using a MMC START STOP UNIT command.
+  @param i_blocks number of blocks expected to be returned.
 
-    @param p_cdio  the CD object to be acted upon.
+  @return \p DRIVER_OP_SUCCESS if we ran the command ok.
+*/
+driver_return_code_t mmc_read_cd(const CdIo_t *p_cdio, void *p_buf, lsn_t i_lsn,
+                                 int expected_sector_type,
+                                 bool b_digital_audio_play, bool b_sync,
+                                 uint8_t header_codes, bool b_user_data,
+                                 bool b_edc_ecc, uint8_t c2_error_information,
+                                 uint8_t subchannel_selection,
+                                 uint16_t i_blocksize, uint32_t i_blocks);
 
-    @param b_eject eject if true and close tray if false
+/**
+   Request information about et drive capabilities via SCSI-MMC READ
+   DISC INFORMATION
 
-    @param b_immediate wait or don't wait for operation to complete
+   @param p_cdio the CD object to be acted upon.
 
-    @param power_condition Set CD-ROM to idle/standby/sleep. If nonzero,
-           eject/load is ignored, so set to 0 if you want to eject or load.
+   @param p_buf pointer to location to store mode sense information
 
-    @param i_timeout_ms value in milliseconds to use on timeout. Setting
-           to 0 uses the default time-out value stored in
-           mmc_timeout_ms.
+   @param i_size number of bytes allocated to p_buf
 
-    @return \p DRIVER_OP_SUCCESS if we ran the command ok.
+   @param data_type kind of information to retrieve.
 
-    @see mmc_eject_media or mmc_close_tray
-  */
-  driver_return_code_t mmc_start_stop_unit(const CdIo_t *p_cdio, bool b_eject,
-                                           bool b_immediate,
-                                           uint8_t power_condition,
-                                           unsigned int i_timeout_ms);
+   @param i_timeout_ms value in milliseconds to use on timeout. Setting
+   to 0 uses the default time-out value stored in
+   mmc_timeout_ms.
 
-    /**
-     Check if drive is ready using SCSI-MMC \p TEST \p UNIT \p READY command.
+   @return DRIVER_OP_SUCCESS (0) if we got the status.
+*/
+driver_return_code_t mmc_read_disc_information(
+    const CdIo_t *p_cdio, /*out*/ void *p_buf, unsigned int i_size,
+    cdio_mmc_read_disc_info_datatype_t data_type, unsigned int i_timeout_ms);
 
-     @param p_cdio  the CD object to be acted upon.
+/**
+  Set the drive speed in K bytes per second using SCSI-MMC SET SPEED.
 
-     @param i_timeout_ms value in milliseconds to use on timeout. Setting
-            to 0 uses the default time-out value stored in
-            \p mmc_timeout_ms.
 
-     @return \p DRIVER_OP_SUCCESS if we ran the command ok.
-  */
-  driver_return_code_t mmc_test_unit_ready(const CdIo_t *p_cdio,
-                                           unsigned int i_timeout_ms);
+  @param p_cdio        CD structure set by cdio_open().
+  @param i_Kbs_speed   speed in K bytes per second. Note this is
+                       not in standard CD-ROM speed units, e.g.
+                       1x, 4x, 16x as it is in cdio_set_speed.
+                       To convert CD-ROM speed units to Kbs,
+                       multiply the number by 176 (for raw data)
+                       and by 150 (for filesystem data).
+                       Also note that ATAPI specs say that a value
+                       less than 176 will result in an error.
+                       On many CD-ROM drives,
+                       specifying a value too large will result in using
+                       the fastest speed.
+
+  @param i_timeout_ms value in milliseconds to use on timeout. Setting
+         to 0 uses the default time-out value stored in
+         mmc_timeout_ms.
+
+  @return the drive speed if greater than 0. -1 if we had an error. is -2
+  returned if this is not implemented for the current driver.
+
+  @see cdio_set_speed and mmc_set_drive_speed
+*/
+driver_return_code_t mmc_set_speed(const CdIo_t *p_cdio, int i_Kbs_speed,
+                                   unsigned int i_timeout_ms);
+
+/**
+  Load or Unload media using a MMC START STOP UNIT command.
+
+  @param p_cdio  the CD object to be acted upon.
+
+  @param b_eject eject if true and close tray if false
+
+  @param b_immediate wait or don't wait for operation to complete
+
+  @param power_condition Set CD-ROM to idle/standby/sleep. If nonzero,
+         eject/load is ignored, so set to 0 if you want to eject or load.
+
+  @param i_timeout_ms value in milliseconds to use on timeout. Setting
+         to 0 uses the default time-out value stored in
+         mmc_timeout_ms.
+
+  @return \p DRIVER_OP_SUCCESS if we ran the command ok.
+
+  @see mmc_eject_media or mmc_close_tray
+*/
+driver_return_code_t mmc_start_stop_unit(const CdIo_t *p_cdio, bool b_eject,
+                                         bool b_immediate,
+                                         uint8_t power_condition,
+                                         unsigned int i_timeout_ms);
+
+/**
+ Check if drive is ready using SCSI-MMC \p TEST \p UNIT \p READY command.
+
+ @param p_cdio  the CD object to be acted upon.
+
+ @param i_timeout_ms value in milliseconds to use on timeout. Setting
+        to 0 uses the default time-out value stored in
+        \p mmc_timeout_ms.
+
+ @return \p DRIVER_OP_SUCCESS if we ran the command ok.
+*/
+driver_return_code_t mmc_test_unit_ready(const CdIo_t *p_cdio,
+                                         unsigned int i_timeout_ms);
 
 /**
    Issue a \p READ \p SUB-CHANNEL command to read current position, \p ISRC or
@@ -378,15 +372,10 @@ extern "C" {
 
    @return \p DRIVER_OP_SUCCESS on success
  */
-driver_return_code_t
-mmc_read_subchannel ( const CdIo_t *p_cdio,
-                             track_t i_track,
-                             unsigned char sub_chan_param,
-                             unsigned int *i_length,
-                             char *p_buf,
-                             unsigned int i_timeout_ms
-                            );
-
+driver_return_code_t mmc_read_subchannel(const CdIo_t *p_cdio, track_t i_track,
+                                         unsigned char sub_chan_param,
+                                         unsigned int *i_length, char *p_buf,
+                                         unsigned int i_timeout_ms);
 
 /**
    Issue a READ TOC/PMA/ATIP command to read the CD-TEXT from R-W
@@ -398,8 +387,8 @@ mmc_read_subchannel ( const CdIo_t *p_cdio,
 
    The first two bytes of the header, a Big-Endian number, specifies
    the number of following bytes. The count also includes the next two
-   header bytes which should be 0. See also Table 495, of the MMC-5
-   specification.
+   header bytes which should be 0. See Section 6.25.3.7 Response Format 0101b:
+   CD-TEXT, and Table 489, page 475 of the MMC-6 draft 2g specification.
 
    Here is code that can be used to get the number of text packs:
    @code
@@ -433,14 +422,14 @@ mmc_read_subchannel ( const CdIo_t *p_cdio,
 
    @return \p DRIVER_OP_SUCCESS on success
  */
-driver_return_code_t
-mmc_read_toc_cdtext ( const CdIo_t *p_cdio, unsigned int *i_length,
-                      unsigned char *p_buf, unsigned int i_timeout_ms );
-
+driver_return_code_t mmc_read_toc_cdtext(const CdIo_t *p_cdio,
+                                         unsigned int *i_length,
+                                         unsigned char *p_buf,
+                                         unsigned int i_timeout_ms);
 
 #ifndef DO_NOT_WANT_OLD_MMC_COMPATIBILITY
-#define mmc_start_stop_media(c, e, i, p, t) \
-    mmc_start_stop_unit(c, e, i, p, t, 0)
+#define mmc_start_stop_media(c, e, i, p, t)                                    \
+  mmc_start_stop_unit(c, e, i, p, t, 0)
 #endif /*DO_NOT_WANT_PARANOIA_COMPATIBILITY*/
 
 #ifdef __cplusplus
@@ -448,7 +437,7 @@ mmc_read_toc_cdtext ( const CdIo_t *p_cdio, unsigned int *i_length,
 #endif /* __cplusplus */
 
 #endif /* CDIO_MMC_HL_CMDS_H_ */
-
+
 /*
  * Local variables:
  *  c-file-style: "gnu"

--- a/include/cdio/posix.h
+++ b/include/cdio/posix.h
@@ -14,8 +14,8 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/*!
- * \file posix.h 
+/**
+ * \file posix.h
  *
  * \brief various POSIX definitions.
 */
@@ -32,7 +32,7 @@ typedef uint16_t unicode16_t;
 #endif /* CDIO_POSIX_H_ */
 
 
-/* 
+/*
  * Local variables:
  *  c-file-style: "gnu"
  *  tab-width: 8

--- a/include/cdio/read.h
+++ b/include/cdio/read.h
@@ -15,10 +15,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file read.h 
+/** \file read.h
  *
  *  \brief The top-level header for sector (block, frame)-related
- *  libcdio calls. 
+ *  libcdio calls.
  */
 
 #ifndef CDIO_READ_H_
@@ -38,21 +38,21 @@ extern "C" {
     CDIO_READ_MODE_M2F1,   /**< Mode 2 Form 1 */
     CDIO_READ_MODE_M2F2    /**< Mode 2 Form 2 */
   } cdio_read_mode_t;
-  
-  /*!
+
+  /**
     Reposition read offset
     Similar to (if not the same as) libc's fseek()
 
     @param p_cdio object which gets adjusted
     @param offset amount to seek
-    @param whence  like corresponding parameter in libc's fseek, e.g. 
+    @param whence  like corresponding parameter in libc's fseek, e.g.
                    SEEK_SET or SEEK_END.
-    @return (off_t) -1 on error. 
+    @return (off_t) -1 on error.
   */
 
   off_t cdio_lseek(const CdIo_t *p_cdio, off_t offset, int whence);
-    
-  /*!  Reads into buf the next size bytes.  Similar to (if not the
+
+  /**  Reads into buf the next size bytes.  Similar to (if not the
     same as) libc's read(). This is a "cooked" read, or one handled by
     the OS. It probably won't work on audio data. For that use
     cdio_read_audio_sector(s).
@@ -62,11 +62,11 @@ extern "C" {
                  this location can store at least i_size bytes.
     @param i_size number of bytes to read
 
-    @return (ssize_t) -1 on error. 
+    @return (ssize_t) -1 on error.
   */
   ssize_t cdio_read(const CdIo_t *p_cdio, void *p_buf, size_t i_size);
-    
-  /*!
+
+  /**
     Read an audio sector
 
     @param p_cdio object to read from
@@ -75,10 +75,10 @@ extern "C" {
                  bytes.
     @param i_lsn sector to read
   */
-  driver_return_code_t cdio_read_audio_sector (const CdIo_t *p_cdio, 
+  driver_return_code_t cdio_read_audio_sector (const CdIo_t *p_cdio,
                                                void *p_buf, lsn_t i_lsn);
 
-  /*!
+  /**
     Reads audio sectors
 
     @param p_cdio object to read from
@@ -88,102 +88,102 @@ extern "C" {
     @param i_lsn sector to read
     @param i_blocks number of sectors to read
   */
-  driver_return_code_t cdio_read_audio_sectors (const CdIo_t *p_cdio, 
+  driver_return_code_t cdio_read_audio_sectors (const CdIo_t *p_cdio,
                                                 void *p_buf, lsn_t i_lsn,
                                                 uint32_t i_blocks);
 
-  /*!
+  /**
     Read data sectors
 
     @param p_cdio object to read from
     @param p_buf place to read data into.  The caller should make sure
-                 this location can store at least ISO_BLOCKSIZE, 
+                 this location can store at least ISO_BLOCKSIZE,
                  M2RAW_SECTOR_SIZE, or M2F2_SECTOR_SIZE depending
-                 on the kind of sector getting read. If you don't 
+                 on the kind of sector getting read. If you don't
                  know whether you have a Mode 1/2, Form 1/ Form 2/Formless
-                 sector best to reserve space for the maximum, 
+                 sector best to reserve space for the maximum,
                  M2RAW_SECTOR_SIZE.
     @param i_lsn sector to read
-    @param i_blocksize size of block. Should be either CDIO_CD_FRAMESIZE, 
+    @param i_blocksize size of block. Should be either CDIO_CD_FRAMESIZE,
     M2RAW_SECTOR_SIZE, or M2F2_SECTOR_SIZE. See comment above under p_buf.
 
     @param i_blocks number of blocks to read
   */
-  driver_return_code_t cdio_read_data_sectors ( const CdIo_t *p_cdio, 
+  driver_return_code_t cdio_read_data_sectors ( const CdIo_t *p_cdio,
                                                 void *p_buf, lsn_t i_lsn,
                                                 uint16_t i_blocksize,
                                                 uint32_t i_blocks );
-  /*!
+  /**
     Reads a mode 1 sector
 
     @param p_cdio object to read from
     @param p_buf place to read data into.
     @param i_lsn sector to read
-    @param b_form2 true for reading mode 1 form 2 sectors or false for 
+    @param b_form2 true for reading mode 1 form 2 sectors or false for
     mode 1 form 1 sectors.
   */
-  driver_return_code_t cdio_read_mode1_sector (const CdIo_t *p_cdio, 
-                                               void *p_buf, lsn_t i_lsn, 
+  driver_return_code_t cdio_read_mode1_sector (const CdIo_t *p_cdio,
+                                               void *p_buf, lsn_t i_lsn,
                                                bool b_form2);
-  /*!
+  /**
     Reads mode 1 sectors
 
     @param p_cdio object to read from
     @param p_buf place to read data into
     @param i_lsn sector to read
-    @param b_form2 true for reading mode 1 form 2 sectors or false for 
+    @param b_form2 true for reading mode 1 form 2 sectors or false for
     mode 1 form 1 sectors.
     @param i_blocks number of sectors to read
   */
-  driver_return_code_t cdio_read_mode1_sectors (const CdIo_t *p_cdio, 
-                                                void *p_buf, lsn_t i_lsn, 
-                                                bool b_form2, 
+  driver_return_code_t cdio_read_mode1_sectors (const CdIo_t *p_cdio,
+                                                void *p_buf, lsn_t i_lsn,
+                                                bool b_form2,
                                                 uint32_t i_blocks);
-  /*!
+  /**
     Reads a mode 2 sector
 
     @param p_cdio object to read from
     @param p_buf place to read data into. The caller should make sure
-                 this location can store at least 
-                 M2RAW_SECTOR_SIZE (for form 1) or CDIO_CD_FRAMESIZE (for 
+                 this location can store at least
+                 M2RAW_SECTOR_SIZE (for form 1) or CDIO_CD_FRAMESIZE (for
                  form 2) bytes.
     @param i_lsn sector to read
-    @param b_form2 true for reading mode 2 form 2 sectors or false for 
+    @param b_form2 true for reading mode 2 form 2 sectors or false for
     mode 2 form 1 sectors.
 
     @return 0 if no error, nonzero otherwise.
   */
-  driver_return_code_t cdio_read_mode2_sector (const CdIo_t *p_cdio, 
-                                               void *p_buf, lsn_t i_lsn, 
+  driver_return_code_t cdio_read_mode2_sector (const CdIo_t *p_cdio,
+                                               void *p_buf, lsn_t i_lsn,
                                                bool b_form2);
-  
+
   /** The special case of reading a single block is a common one so we
       provide a routine for that as a convenience.
   */
-  driver_return_code_t cdio_read_sector(const CdIo_t *p_cdio, void *p_buf, 
-                                        lsn_t i_lsn, 
+  driver_return_code_t cdio_read_sector(const CdIo_t *p_cdio, void *p_buf,
+                                        lsn_t i_lsn,
                                         cdio_read_mode_t read_mode);
-  /*!
+  /**
     Reads mode 2 sectors
 
     @param p_cdio object to read from
     @param p_buf place to read data into. The caller should make sure
-                 this location can store at least 
-                 M2RAW_SECTOR_SIZE (for form 1) or CDIO_CD_FRAMESIZE (for 
+                 this location can store at least
+                 M2RAW_SECTOR_SIZE (for form 1) or CDIO_CD_FRAMESIZE (for
                  form 2) * i_blocks bytes.
     @param i_lsn sector to read
-    @param b_form2 true for reading mode2 form 2 sectors or false for 
+    @param b_form2 true for reading mode2 form 2 sectors or false for
            mode 2  form 1 sectors.
     @param i_blocks number of sectors to read
 
     @return 0 if no error, nonzero otherwise.
   */
-  driver_return_code_t cdio_read_mode2_sectors (const CdIo_t *p_cdio, 
-                                                void *p_buf, lsn_t i_lsn, 
-                                                bool b_form2, 
+  driver_return_code_t cdio_read_mode2_sectors (const CdIo_t *p_cdio,
+                                                void *p_buf, lsn_t i_lsn,
+                                                bool b_form2,
                                                 uint32_t i_blocks);
-  
-  /*!
+
+  /**
     Reads a number of sectors (AKA blocks).
 
     @param p_cdio cdio object
@@ -199,21 +199,21 @@ extern "C" {
       *p_buf should hold at least CDIO_FRAMESIZE_RAW * i_blocks bytes.
 
     If read_mode is CDIO_MODE_DATA,
-      *p_buf should hold at least i_blocks times either ISO_BLOCKSIZE, 
-      M1RAW_SECTOR_SIZE or M2F2_SECTOR_SIZE depending on the kind of 
-      sector getting read. If you don't know whether you have a Mode 1/2, 
+      *p_buf should hold at least i_blocks times either ISO_BLOCKSIZE,
+      M1RAW_SECTOR_SIZE or M2F2_SECTOR_SIZE depending on the kind of
+      sector getting read. If you don't know whether you have a Mode 1/2,
     Form 1/ Form 2/Formless sector best to reserve space for the maximum
     which is M2RAW_SECTOR_SIZE.
 
     If read_mode is CDIO_MODE_M2F1,
     *p_buf should hold at least M2RAW_SECTOR_SIZE * i_blocks bytes.
-    
+
     If read_mode is CDIO_MODE_M2F2,
     *p_buf should hold at least CDIO_CD_FRAMESIZE * i_blocks bytes.
-    
+
   */
-  driver_return_code_t cdio_read_sectors(const CdIo_t *p_cdio, void *p_buf, 
-                                         lsn_t i_lsn, 
+  driver_return_code_t cdio_read_sectors(const CdIo_t *p_cdio, void *p_buf,
+                                         lsn_t i_lsn,
                                          cdio_read_mode_t read_mode,
                                          uint32_t i_blocks);
 

--- a/include/cdio/rock.h
+++ b/include/cdio/rock.h
@@ -17,7 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/*!
+/**
    \file rock.h
    \brief Things related to the Rock Ridge Interchange Protocol (RRIP)
 
@@ -35,7 +35,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-/*! An enumeration for some of the ISO_ROCK_* \#defines below. This isn't
+/** An enumeration for some of the ISO_ROCK_* \#defines below. This isn't
   really an enumeration one would really use in a program it is to
   be helpful in debuggers where wants just to refer to the ISO_ROCK_*
   names and get something.
@@ -91,18 +91,18 @@ extern enum iso_rock_enums {
 
 PRAGMA_BEGIN_PACKED
 
-/*! The next two structs are used by the system-use-sharing protocol
+/** The next two structs are used by the system-use-sharing protocol
    (SUSP), in which the Rock Ridge extensions are embedded.  It is
    quite possible that other extensions are present on the disk, and
    this is fine as long as they all use SUSP. */
 
-/*! system-use-sharing protocol */
+/** system-use-sharing protocol */
 typedef struct iso_su_sp_s{
   uint8_t       magic[2];
   uint8_t       skip;
 } GNUC_PACKED iso_su_sp_t;
 
-/*! system-use extension record */
+/** system-use extension record */
 typedef struct iso_su_er_s {
   iso711_t      len_id;  /**< Identifier length. Value 10?. */
   uint8_t       len_des;
@@ -117,19 +117,19 @@ typedef struct iso_su_ce_s {
   iso733_t      size;
 } GNUC_PACKED iso_su_ce_t;
 
-/*! POSIX file attributes, PX. See Rock Ridge Section 4.1.2 */
+/** POSIX file attributes, PX. See Rock Ridge Section 4.1.2 */
 typedef struct iso_rock_px_s {
-  iso733_t st_mode;       /*! file mode permissions; same as st_mode
+  iso733_t st_mode;       /** file mode permissions; same as st_mode
                             of POSIX:5.6.1 */
-  iso733_t st_nlinks;     /*! number of links to file; same as st_nlinks
+  iso733_t st_nlinks;     /** number of links to file; same as st_nlinks
                             of POSIX:5.6.1 */
-  iso733_t st_uid;        /*! user id owner of file; same as st_uid
+  iso733_t st_uid;        /** user id owner of file; same as st_uid
                             of POSIX:5.6.1 */
-  iso733_t st_gid;        /*! group id of file; same as st_gid of
+  iso733_t st_gid;        /** group id of file; same as st_gid of
                             of POSIX:5.6.1 */
 } GNUC_PACKED iso_rock_px_t ;
 
-/*! POSIX device number, PN. A PN is mandatory if the file type
+/** POSIX device number, PN. A PN is mandatory if the file type
   recorded in the "PX" File Mode field for a Directory Record
   indicates a character or block device (ISO_ROCK_ISCHR |
   ISO_ROCK_ISBLK).  This entry is ignored for other (non-Direcotry)
@@ -144,7 +144,7 @@ typedef struct iso_rock_pn_s {
                             7.2.3 encoded */
 } GNUC_PACKED iso_rock_pn_t ;
 
-/*! These are the bits and their meanings for flags in the SL structure. */
+/** These are the bits and their meanings for flags in the SL structure. */
 typedef enum {
   ISO_ROCK_SL_CONTINUE = 1,
   ISO_ROCK_SL_CURRENT  = 2,
@@ -163,15 +163,15 @@ typedef struct iso_rock_sl_part_s {
   char text[EMPTY_ARRAY_SIZE];
 } GNUC_PACKED iso_rock_sl_part_t ;
 
-/*! Symbolic link. See Rock Ridge Section 4.1.3 */
+/** Symbolic link. See Rock Ridge Section 4.1.3 */
 typedef struct iso_rock_sl_s {
   uint8_t flags;
   iso_rock_sl_part_t link;
 } GNUC_PACKED iso_rock_sl_t ;
 
-/*! Alternate name. See Rock Ridge Section 4.1.4 */
+/** Alternate name. See Rock Ridge Section 4.1.4 */
 
-/*! These are the bits and their meanings for flags in the NM structure. */
+/** These are the bits and their meanings for flags in the NM structure. */
 typedef enum {
   ISO_ROCK_NM_CONTINUE = 1,
   ISO_ROCK_NM_CURRENT  = 2,
@@ -188,17 +188,17 @@ typedef struct iso_rock_nm_s {
   char name[EMPTY_ARRAY_SIZE];
 } GNUC_PACKED iso_rock_nm_t ;
 
-/*! Child link. See Section 4.1.5.1 */
+/** Child link. See Section 4.1.5.1 */
 typedef struct iso_rock_cl_s {
   iso733_t location;
 } GNUC_PACKED iso_rock_cl_t ;
 
-/*! Parent link. See Section 4.1.5.2 */
+/** Parent link. See Section 4.1.5.2 */
 typedef struct iso_rock_pl_s {
   iso733_t location;
 } GNUC_PACKED iso_rock_pl_t ;
 
-/*! These are the bits and their meanings for flags in the TF structure. */
+/** These are the bits and their meanings for flags in the TF structure. */
 typedef enum {
   ISO_ROCK_TF_CREATE     =  1,
   ISO_ROCK_TF_MODIFY     =  2,
@@ -220,7 +220,7 @@ typedef enum {
 #define ISO_ROCK_TF_EFFECTIVE  64
 #define ISO_ROCK_TF_LONG_FORM 128
 
-/*! Time stamp(s) for a file. See Rock Ridge Section 4.1.6 */
+/** Time stamp(s) for a file. See Rock Ridge Section 4.1.6 */
 typedef struct iso_rock_tf_s {
   uint8_t flags; /**< See ISO_ROCK_TF_* bits above. */
   uint8_t time_bytes[EMPTY_ARRAY_SIZE]; /**< A homogeneous array of
@@ -236,7 +236,7 @@ typedef struct iso_rock_tf_s {
                                            extraction.  */
 } GNUC_PACKED iso_rock_tf_t ;
 
-/*! File data in sparse format. See Rock Ridge Section 4.1.7 */
+/** File data in sparse format. See Rock Ridge Section 4.1.7 */
 typedef struct iso_rock_sf_s {
   iso733_t virtual_size_high; /**< high-order 32 bits of virtual size */
   iso733_t virtual_size_low;  /**< low-order 32 bits of virtual size */
@@ -335,7 +335,7 @@ typedef struct iso_rock_statbuf_s {
 
 PRAGMA_END_PACKED
 
-/*! return length of name field; 0: not found, -1: to be ignored */
+/** return length of name field; 0: not found, -1: to be ignored */
 int get_rock_ridge_filename(iso9660_dir_t * de,
                             /*in*/ void * p_iso,
                             /*out*/ char * retname,
@@ -344,13 +344,13 @@ int get_rock_ridge_filename(iso9660_dir_t * de,
 int parse_rock_ridge_stat(iso9660_dir_t *de,
                           /*out*/ iso9660_stat_t *p_stat);
 
-  /*!
+  /**
     Returns POSIX mode bitstring for a given file.
   */
   mode_t
   iso9660_get_posix_filemode_from_rock(const iso_rock_statbuf_t *rr);
 
-/*!
+/**
   Returns a string which interpreting the POSIX mode st_mode.
   For example:
   \verbatim

--- a/include/cdio/scsi_mmc.h
+++ b/include/cdio/scsi_mmc.h
@@ -15,10 +15,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/*!
- *  \file scsi_mmc.h 
- * 
- *  \brief Obsolete please use <cdio/mmc.h> instead. 
+/**
+ *  \file scsi_mmc.h
+ *
+ *  \brief Obsolete please use <cdio/mmc.h> instead.
 */
 /* ust a moment while, I transfer your call... */
 #include <cdio/mmc.h>

--- a/include/cdio/sector.h
+++ b/include/cdio/sector.h
@@ -16,8 +16,8 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/*!
-   \file sector.h 
+/**
+   \file sector.h
    \brief Things related to CD-ROM layout: tracks, sector sizes, MSFs, LBAs.
 
   A CD-ROM physical sector size is 2048, 2052, 2056, 2324, 2332, 2336,
@@ -25,7 +25,7 @@
 
   Sector types of the standard CD-ROM data formats:
 
-\verbatim 
+\verbatim
   format   sector type               user data size (bytes)
   -----------------------------------------------------------------------------
     1     (Red Book)    CD-DA          2352    (CDIO_CD_FRAMESIZE_RAW)
@@ -33,26 +33,26 @@
     3     (Yellow Book) Mode1 Form2    2336    (M2RAW_SECTOR_SIZE)
     4     (Green Book)  Mode2 Form1    2048    (CDIO_CD_FRAMESIZE)
     5     (Green Book)  Mode2 Form2    2328    (2324+4 spare bytes)
- 
- 
+
+
         The layout of the standard CD-ROM data formats:
   -----------------------------------------------------------------------------
   - audio (red):                  | audio_sample_bytes |
                                   |        2352        |
- 
+
   - data (yellow, mode1):         | sync - head - data - EDC - zero - ECC |
                                   |  12  -   4  - 2048 -  4  -   8  - 276 |
- 
+
   - data (yellow, mode2):         | sync - head - data |
                                  |  12  -   4  - 2336 |
- 
+
   - XA data (green, mode2 form1): | sync - head - sub - data - EDC - ECC |
                                   |  12  -   4  -  8  - 2048 -  4  - 276 |
- 
+
   - XA data (green, mode2 form2): | sync - head - sub - data - Spare |
                                   |  12  -   4  -  8  - 2324 -  4    |
 \endverbatim
- 
+
 
 */
 
@@ -65,7 +65,7 @@
 
 #include <cdio/types.h>
 
-      /*! Information that can be obtained through a Read Subchannel
+      /** Information that can be obtained through a Read Subchannel
         command.
       */
       typedef enum cdio_subchannel
@@ -75,8 +75,8 @@
           CDIO_SUBCHANNEL_MEDIA_CATALOG         = 2,
           CDIO_SUBCHANNEL_TRACK_ISRC            = 3
         } cdio_subchannel;
-      
-      /*! track flags
+
+      /** track flags
        * Q Sub-channel Control Field (4.2.3.3)
        */
       typedef enum {
@@ -87,11 +87,11 @@
         FOUR_CHANNEL_AUDIO =    0x08,   /* 4 audio channels */
         SCMS =                  0x10    /* SCMS (5.29.2.7) */
       } flag_t;
-      
+
 #define CDIO_PREGAP_SECTORS  150
 #define CDIO_POSTGAP_SECTORS 150
-      
-      /*! An enumeration for some of the CDIO_CD \#defines below. This isn't
+
+      /** An enumeration for some of the CDIO_CD \#defines below. This isn't
         really an enumeration one would really use in a program it is to
         be helpful in debuggers where wants just to refer to the CDIO_CD_
         names and get something.
@@ -101,32 +101,32 @@
                                              a limit */
         CDIO_CD_SECS_PER_MIN =      60,   /**< seconds per minute */
         CDIO_CD_FRAMES_PER_SEC =    75,   /**< frames per second */
-        CDIO_CD_SYNC_SIZE =         12,   /**< 12 sync bytes per raw data 
+        CDIO_CD_SYNC_SIZE =         12,   /**< 12 sync bytes per raw data
                                              frame */
-        CDIO_CD_CHUNK_SIZE =        24,   /**< lowest-level "data bytes 
+        CDIO_CD_CHUNK_SIZE =        24,   /**< lowest-level "data bytes
                                              piece" */
         CDIO_CD_NUM_OF_CHUNKS =     98,   /**< chunks per frame */
         CDIO_CD_FRAMESIZE_SUB =     96,   /**< subchannel data "frame" size */
         CDIO_CD_HEADER_SIZE =        4,   /**< header (address) bytes per raw
                                              frame */
-        CDIO_CD_SUBHEADER_SIZE =     8,   /**< subheader bytes per raw XA data 
+        CDIO_CD_SUBHEADER_SIZE =     8,   /**< subheader bytes per raw XA data
                                              frame */
-        CDIO_CD_ECC_SIZE =         276,   /**< bytes ECC per most raw data 
+        CDIO_CD_ECC_SIZE =         276,   /**< bytes ECC per most raw data
                                              frame types */
-        CDIO_CD_FRAMESIZE =       2048,   /**< bytes per frame, "cooked" 
+        CDIO_CD_FRAMESIZE =       2048,   /**< bytes per frame, "cooked"
                                              mode */
         CDIO_CD_FRAMESIZE_RAW =   2352,   /**< bytes per frame, "raw" mode */
-        CDIO_CD_FRAMESIZE_RAWER = 2646,   /**< The maximum possible 
+        CDIO_CD_FRAMESIZE_RAWER = 2646,   /**< The maximum possible
                                              returned  */
         CDIO_CD_FRAMESIZE_RAW1  = 2340,
         CDIO_CD_FRAMESIZE_RAW0  = 2336,
-        CDIO_CD_MAX_SESSIONS =      99, 
+        CDIO_CD_MAX_SESSIONS =      99,
         CDIO_CD_MIN_SESSION_NO =     1,   /**<, Smallest CD session number */
         CDIO_CD_MAX_LSN =       450150,   /**< Largest LSN in a CD */
         CDIO_CD_MIN_LSN      = -450150,   /**< Smallest LSN in a CD */
       } cdio_cd_enums;
-        
-      /*!
+
+      /**
         Some generally useful CD-ROM information -- mostly based on the above.
         This is from linux.h - not to slight other OS's. This was the first
         place I came across such useful stuff.
@@ -141,38 +141,38 @@
 #define CDIO_CD_FRAMESIZE_SUB     96   /**< subchannel data "frame" size */
 #define CDIO_CD_HEADER_SIZE        4   /**< header (address) bytes per raw
                                           data frame */
-#define CDIO_CD_SUBHEADER_SIZE     8   /**< subheader bytes per raw XA data 
+#define CDIO_CD_SUBHEADER_SIZE     8   /**< subheader bytes per raw XA data
                                             frame */
 #define CDIO_CD_EDC_SIZE           4   /**< bytes EDC per most raw data
                                           frame types */
 #define CDIO_CD_M1F1_ZERO_SIZE     8   /**< bytes zero per yellow book mode
                                           1 frame */
-#define CDIO_CD_ECC_SIZE         276   /**< bytes ECC per most raw data frame 
+#define CDIO_CD_ECC_SIZE         276   /**< bytes ECC per most raw data frame
                                           types */
 #define CDIO_CD_FRAMESIZE       2048   /**< bytes per frame, "cooked" mode */
 #define CDIO_CD_FRAMESIZE_RAW   2352   /**< bytes per frame, "raw" mode */
-#define CDIO_CD_FRAMESIZE_RAWER 2646   /**< The maximum possible returned 
-                                          bytes */ 
+#define CDIO_CD_FRAMESIZE_RAWER 2646   /**< The maximum possible returned
+                                          bytes */
 #define CDIO_CD_FRAMESIZE_RAW1 (CDIO_CD_FRAMESIZE_RAW-CDIO_CD_SYNC_SIZE) /*2340*/
 #define CDIO_CD_FRAMESIZE_RAW0 (CDIO_CD_FRAMESIZE_RAW-CDIO_CD_SYNC_SIZE-CDIO_CD_HEADER_SIZE) /*2336*/
-      
-      /*! "before data" part of raw XA (green, mode2) frame */
-#define CDIO_CD_XA_HEADER (CDIO_CD_HEADER_SIZE+CDIO_CD_SUBHEADER_SIZE) 
-      
-      /*! "after data" part of raw XA (green, mode2 form1) frame */
-#define CDIO_CD_XA_TAIL   (CDIO_CD_EDC_SIZE+CDIO_CD_ECC_SIZE) 
-      
-      /*! "before data" sync bytes + header of XA (green, mode2) frame */
-#define CDIO_CD_XA_SYNC_HEADER   (CDIO_CD_SYNC_SIZE+CDIO_CD_XA_HEADER) 
-      
-      /*! String of bytes used to identify the beginning of a Mode 1 or
+
+      /** "before data" part of raw XA (green, mode2) frame */
+#define CDIO_CD_XA_HEADER (CDIO_CD_HEADER_SIZE+CDIO_CD_SUBHEADER_SIZE)
+
+      /** "after data" part of raw XA (green, mode2 form1) frame */
+#define CDIO_CD_XA_TAIL   (CDIO_CD_EDC_SIZE+CDIO_CD_ECC_SIZE)
+
+      /** "before data" sync bytes + header of XA (green, mode2) frame */
+#define CDIO_CD_XA_SYNC_HEADER   (CDIO_CD_SYNC_SIZE+CDIO_CD_XA_HEADER)
+
+      /** String of bytes used to identify the beginning of a Mode 1 or
           Mode 2 sector. */
       extern const uint8_t CDIO_SECTOR_SYNC_HEADER[CDIO_CD_SYNC_SIZE];
-      /**<  
+      /**<
         {0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0};
       */
-      
-      /*! An enumeration for some of the M2*_SECTOR_SIZE \#defines
+
+      /** An enumeration for some of the M2*_SECTOR_SIZE \#defines
         below. This isn't really an enumeration one would really use in a
         program it is to be helpful in debuggers where wants just to refer
         to the M2*_SECTOR_SIZE names and get something.
@@ -182,93 +182,93 @@
         M2SUB_SECTOR_SIZE = 2332,
         M2RAW_SECTOR_SIZE = 2336
       } m2_sector_enums;
-      
+
 #define M2F2_SECTOR_SIZE    2324
 #define M2SUB_SECTOR_SIZE   2332
 #define M2RAW_SECTOR_SIZE   2336
-      
-      /*! Largest CD session number */
-#define CDIO_CD_MAX_SESSIONS    99 
-      /*! Smallest CD session number */
+
+      /** Largest CD session number */
+#define CDIO_CD_MAX_SESSIONS    99
+      /** Smallest CD session number */
 #define CDIO_CD_MIN_SESSION_NO   1
-      
-      /*! Largest LSN in a CD */
+
+      /** Largest LSN in a CD */
 #define CDIO_CD_MAX_LSN   450150
-      /*! Smallest LSN in a CD */
+      /** Smallest LSN in a CD */
 #define CDIO_CD_MIN_LSN  -450150
-      
-      
+
+
 #define CDIO_CD_FRAMES_PER_MIN                          \
       (CDIO_CD_FRAMES_PER_SEC*CDIO_CD_SECS_PER_MIN)
-      
+
 typedef enum cdio_cd_minutes_sectors
 {
         CDIO_CD_74MIN_SECTORS = UINT32_C(74) * CDIO_CD_FRAMES_PER_MIN,
         CDIO_CD_80MIN_SECTORS = UINT32_C(80) * CDIO_CD_FRAMES_PER_MIN,
         CDIO_CD_90MIN_SECTORS = UINT32_C(90) * CDIO_CD_FRAMES_PER_MIN,
-      
+
         CDIO_CD_MAX_SECTORS   = UINT32_C(100) * CDIO_CD_FRAMES_PER_MIN - CDIO_PREGAP_SECTORS
 } cdio_cd_minutes_sectors;
-      
+
 #define msf_t_SIZEOF 3
-      
-      /*! 
+
+      /**
         Convert an LBA into a string representation of the MSF.
         \warning cdio_lba_to_msf_str returns new allocated string */
       char *cdio_lba_to_msf_str (lba_t i_lba);
-      
-      /*! 
+
+      /**
         Convert an MSF into a string representation of the MSF.
         \warning cdio_msf_to_msf_str returns new allocated string */
       char *cdio_msf_to_str (const msf_t *p_msf);
-      
-      /*! 
+
+      /**
         Convert an LBA into the corresponding LSN.
       */
       lba_t cdio_lba_to_lsn (lba_t i_lba);
-      
-      /*! 
+
+      /**
         Convert an LBA into the corresponding MSF.
       */
       void  cdio_lba_to_msf(lba_t i_lba, msf_t *p_msf);
-      
-      /*! 
+
+      /**
         Convert an LSN into the corresponding LBA.
         CDIO_INVALID_LBA is returned if there is an error.
       */
       lba_t cdio_lsn_to_lba (lsn_t i_lsn);
-      
-      /*! 
+
+      /**
         Convert an LSN into the corresponding MSF.
       */
       void  cdio_lsn_to_msf (lsn_t i_lsn, msf_t *p_msf);
-      
-      /*! 
+
+      /**
         Convert a MSF into the corresponding LBA.
         CDIO_INVALID_LBA is returned if there is an error.
       */
       lba_t cdio_msf_to_lba (const msf_t *p_msf);
-      
-      /*! 
+
+      /**
         Convert a MSF into the corresponding LSN.
         CDIO_INVALID_LSN is returned if there is an error.
       */
       lsn_t cdio_msf_to_lsn (const msf_t *p_msf);
-      
-      /*!  
+
+      /**
         Convert a MSF - broken out as 3 integer components into the
-        corresponding LBA.  
+        corresponding LBA.
         CDIO_INVALID_LBA is returned if there is an error.
       */
-      lba_t cdio_msf3_to_lba (unsigned int minutes, unsigned int seconds, 
+      lba_t cdio_msf3_to_lba (unsigned int minutes, unsigned int seconds,
                               unsigned int frames);
-      
-      /*! 
+
+      /**
         Convert a string of the form MM:SS:FF into the corresponding LBA.
         CDIO_INVALID_LBA is returned if there is an error.
       */
       lba_t cdio_mmssff_to_lba (const char *psz_mmssff);
-      
+
 #ifdef __cplusplus
     }
 #endif
@@ -281,7 +281,7 @@ typedef enum cdio_cd_minutes_sectors
 #endif /* CDIO_SECTOR_H_ */
 
 
-/* 
+/*
  * Local variables:
  *  c-file-style: "gnu"
  *  tab-width: 8

--- a/include/cdio/track.h
+++ b/include/cdio/track.h
@@ -25,7 +25,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-  /*! Printable tags for track_format_t enumeration.  */
+  /** Printable tags for track_format_t enumeration.  */
   extern const char *track_format2str[6];
 
   typedef enum  {
@@ -46,7 +46,7 @@ extern "C" {
     CDIO_TRACK_FLAG_UNKNOWN
   } track_flag_t;
 
-  /*! \brief Structure containing attributes associated with a track */
+  /** \brief Structure containing attributes associated with a track */
   typedef struct {
     track_flag_t preemphasis; /**< Linear preemphasis on an audio track */
     track_flag_t copy_permit; /**< Whether copying is permitted */
@@ -55,14 +55,14 @@ extern "C" {
                               */
   } track_flags_t;
 
-  /*! The leadout track is always 0xAA, regardless of # of tracks on
+  /** The leadout track is always 0xAA, regardless of # of tracks on
     disc, or what value may be used internally. For example although
     OS X uses a different value for the lead-out track internally than
     given below, programmers should use CDIO_CDROM_LEADOUT_TRACK and
     not worry about this.
   */
 
-  /*! An enumeration for some of the CDIO_CDROM_* \#defines below. This
+  /** An enumeration for some of the CDIO_CDROM_* \#defines below. This
     isn't really an enumeration one would really use in a program; it
     is to be helpful in debuggers where wants just to refer to the
     CDIO_CDROM_* names and get something.
@@ -82,7 +82,7 @@ extern "C" {
 
 #define CDIO_CD_MIN_TRACK_NO  1 /**< Smallest CD track number */
 
-  /*! track modes (Table 350)
+  /** track modes (Table 350)
     reference: MMC-3 draft revision - 10g
   */
   typedef enum {
@@ -96,7 +96,7 @@ extern "C" {
     MODE2_RAW                   /**< 2352 byte block length */
   } trackmode_t;
 
-  /*!
+  /**
     Get the number of the first track.
 
     @return the track number or CDIO_INVALID_TRACK
@@ -104,14 +104,14 @@ extern "C" {
   */
   track_t cdio_get_first_track_num(const CdIo_t *p_cdio);
 
-  /*!
+  /**
     Return the last track number.
     CDIO_INVALID_TRACK is returned on error.
   */
   track_t cdio_get_last_track_num (const CdIo_t *p_cdio);
 
 
-  /*! Find the track which contains lsn.
+  /** Find the track which contains lsn.
     CDIO_INVALID_TRACK is returned if the lsn outside of the CD or
     if there was some error.
 
@@ -120,24 +120,24 @@ extern "C" {
   */
   track_t cdio_get_track(const CdIo_t *p_cdio, lsn_t lsn);
 
-  /*! Return number of channels in track: 2 or 4; -2 if not
+  /** Return number of channels in track: 2 or 4; -2 if not
       implemented or -1 for error.
       Not meaningful if track is not an audio track.
   */
   int cdio_get_track_channels(const CdIo_t *p_cdio, track_t i_track);
 
-  /*! Return copy protection status on a track. Is this meaningful
+  /** Return copy protection status on a track. Is this meaningful
       if not an audio track?
    */
   track_flag_t cdio_get_track_copy_permit(const CdIo_t *p_cdio,
                                           track_t i_track);
 
-  /*!
+  /**
     Get the format (audio, mode2, mode1) of track.
   */
   track_format_t cdio_get_track_format(const CdIo_t *p_cdio, track_t i_track);
 
-  /*!
+  /**
     Return true if we have XA data (green, mode2 form1) or
     XA data (green, mode2 form2). That is track begins:
     sync - header - subheader
@@ -147,13 +147,13 @@ extern "C" {
   */
   bool cdio_get_track_green(const CdIo_t *p_cdio, track_t i_track);
 
-  /*!
+  /**
     Return the ending LSN for track number
     i_track in cdio.  CDIO_INVALID_LSN is returned on error.
   */
   lsn_t cdio_get_track_last_lsn(const CdIo_t *p_cdio, track_t i_track);
 
-  /*!
+  /**
     Get the starting LBA for track number
     i_track in p_cdio.  Track numbers usually start at something
     greater than 0, usually 1.
@@ -167,7 +167,7 @@ extern "C" {
   */
   lba_t cdio_get_track_lba(const CdIo_t *p_cdio, track_t i_track);
 
-  /*!
+  /**
     Return the starting LSN for track number
     i_track in p_cdio.  Track numbers usually start at something
     greater than 0, usually 1.
@@ -181,7 +181,7 @@ extern "C" {
   */
   lsn_t cdio_get_track_lsn(const CdIo_t *p_cdio, track_t i_track);
 
-  /*!
+  /**
     Return the starting LBA for the pregap for track number
     i_track in p_cdio.  Track numbers usually start at something
     greater than 0, usually 1.
@@ -192,7 +192,7 @@ extern "C" {
   */
   lba_t cdio_get_track_pregap_lba(const CdIo_t *p_cdio, track_t i_track);
 
-  /*!
+  /**
     Return the starting LSN for the pregap for track number
     i_track in p_cdio.  Track numbers usually start at something
     greater than 0, usually 1.
@@ -203,7 +203,7 @@ extern "C" {
   */
   lsn_t cdio_get_track_pregap_lsn(const CdIo_t *p_cdio, track_t i_track);
 
-  /*!
+  /**
     Get the International Standard Recording Code (ISRC) for track number
     i_track in p_cdio.  Track numbers usually start at something
     greater than 0, usually 1.
@@ -217,7 +217,7 @@ extern "C" {
   */
   char * cdio_get_track_isrc (const CdIo_t *p_cdio, track_t i_track);
 
-  /*!
+  /**
     Return the starting MSF (minutes/secs/frames) for track number
     i_track in p_cdio.  Track numbers usually start at something
     greater than 0, usually 1.
@@ -230,13 +230,13 @@ extern "C" {
   bool cdio_get_track_msf(const CdIo_t *p_cdio, track_t i_track,
                           /*out*/ msf_t *msf);
 
-  /*! Get linear preemphasis status on an audio track
+  /** Get linear preemphasis status on an audio track
       This is not meaningful if not an audio track?
    */
   track_flag_t cdio_get_track_preemphasis(const CdIo_t *p_cdio,
                                           track_t i_track);
 
-  /*!
+  /**
     Get the number of sectors between this track an the next.  This
     includes any pregap sectors before the start of the next track.
     Track numbers usually start at something

--- a/include/cdio/types.h
+++ b/include/cdio/types.h
@@ -183,7 +183,7 @@ typedef uint8_t ubyte;
   /** our own offsetof()-like macro */
 #define __cd_offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
 
-  /*!
+  /**
     \brief MSF (minute/second/frame) structure
 
     One CD-ROMs addressing scheme especially used in audio formats
@@ -207,7 +207,7 @@ typedef uint8_t ubyte;
 
 #define msf_t_SIZEOF 3
 
-  /*!
+  /**
     \brief UTF-8 char definition
 
     Type to denote UTF-8 strings.
@@ -233,14 +233,14 @@ typedef uint8_t ubyte;
   typedef uint8_t bitfield_t;
 #endif
 
-  /*! The type of a Logical Block Address. We allow for an lba to be
+  /** The type of a Logical Block Address. We allow for an lba to be
     negative to be consistent with an lba, although I'm not sure this
     this is possible.
 
    */
   typedef int32_t lba_t;
 
-  /*! The type of a Logical Sector Number. Note that an lba can be negative
+  /** The type of a Logical Sector Number. Note that an lba can be negative
     and the MMC3 specs allow for a conversion of a negative lba.
 
     @see msf_t
@@ -254,48 +254,48 @@ typedef uint8_t ubyte;
     lba_t       lba;
   };
 
-  /*! The type of a track number 0..99. */
+  /** The type of a track number 0..99. */
   typedef uint8_t track_t;
 
-  /*! The type of a session number 0..99. */
+  /** The type of a session number 0..99. */
   typedef uint8_t session_t;
 
-  /*!
+  /**
     Constant for invalid session number
   */
 #define CDIO_INVALID_SESSION   0xFF
 
-  /*!
+  /**
     Constant for invalid LBA. It is 151 less than the most negative
     LBA -45150. This provide slack for the 150-frame offset in
     LBA to LSN 150 conversions
   */
 #define CDIO_INVALID_LBA    -45301
 
-  /*!
+  /**
     Constant for invalid LSN
   */
 #define CDIO_INVALID_LSN    CDIO_INVALID_LBA
 
-  /*!
+  /**
     Number of ASCII bytes in a media catalog number (MCN).
     We include an extra 0 byte so these can be used as C strings.
   */
 #define CDIO_MCN_SIZE       13
 
-  /*!
+  /**
     Type to hold ASCII bytes in a media catalog number (MCN).
     We include an extra 0 byte so these can be used as C strings.
   */
   typedef char cdio_mcn_t[CDIO_MCN_SIZE+1];
 
 
-  /*!
+  /**
     Number of ASCII bytes in International Standard Recording Codes (ISRC)
   */
 #define CDIO_ISRC_SIZE       12
 
-  /*!
+  /**
     Type to hold ASCII bytes in a ISRC.
     We include an extra 0 byte so these can be used as C strings.
   */
@@ -303,7 +303,7 @@ typedef uint8_t ubyte;
 
   typedef int cdio_fs_anal_t;
 
-  /*!
+  /**
     track flags
     Q Sub-channel Control Field (4.2.3.3)
   */

--- a/include/cdio/udf.h
+++ b/include/cdio/udf.h
@@ -1,4 +1,4 @@
-/*  
+/*
     Copyright (C) 2005, 2006, 2008, 2010 Rocky Bernstein <rocky@gnu.org>
 
     This program is free software: you can redistribute it and/or modify
@@ -15,8 +15,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/*!
- * \file udf.h 
+/**
+ * \file udf.h
  *
  * \brief The top-level interface header for libudf: UDF filesystem
  * library; applications include this.
@@ -24,7 +24,7 @@
 */
 
 #ifndef UDF_H
-#define UDF_H 
+#define UDF_H
 
 #include <cdio/cdio.h>
 #include <cdio/ecma_167.h>
@@ -33,7 +33,7 @@
 typedef uint16_t partition_num_t;
 
 /** Opaque structures. */
-typedef struct udf_s udf_t; 
+typedef struct udf_s udf_t;
 typedef struct udf_file_s udf_file_t;
 
 typedef struct udf_dirent_s {
@@ -48,7 +48,7 @@ typedef struct udf_dirent_s {
     uint64_t           dir_left;
     uint8_t           *sector;
     udf_fileid_desc_t *fid;
-    
+
     /* This field has to come last because it is variable in length. */
     udf_file_entry_t   fe;
 } udf_dirent_t;
@@ -61,7 +61,7 @@ typedef struct udf_dirent_s {
 */
 typedef enum {
   UDF_BLOCKSIZE       = 2048
-} udf_enum1_t; 
+} udf_enum1_t;
 
 /** This variable is trickery to force the above enum symbol value to
     be recorded in debug symbol tables. It is used to allow one refer
@@ -73,35 +73,35 @@ extern udf_enum1_t debug_udf_enum1;
 extern "C" {
 #endif /* __cplusplus */
 
-  /*!
+  /**
     Close UDF and free resources associated with p_udf.
   */
   bool udf_close (udf_t *p_udf);
-  
-  /*!  
+
+  /**
     Seek to a position i_start and then read i_blocks. Number of
     blocks read is returned. One normally expects the return to be
     equal to i_blocks.
   */
 
-  driver_return_code_t udf_read_sectors (const udf_t *p_udf, void *ptr, 
+  driver_return_code_t udf_read_sectors (const udf_t *p_udf, void *ptr,
                                          lsn_t i_start,  long int i_blocks);
 
-  /*!
+  /**
     Open an UDF for reading. Maybe in the future we will have
     a mode. NULL is returned on error.
-    
+
     Caller must free result - use udf_close for that.
   */
   udf_t *udf_open (const char *psz_path);
-  
-  /*!
-    Return the partition number of the the opened udf handle. -1 
+
+  /**
+    Return the partition number of the the opened udf handle. -1
     Is returned if we have an error.
   */
   int16_t udf_get_part_number(const udf_t *p_udf);
 
-  /*!
+  /**
     Get the root in p_udf. If b_any_partition is false then
     the root must be in the given partition.
     NULL is returned if the partition is not found or a root is not found or
@@ -109,23 +109,23 @@ extern "C" {
 
     Caller must free result - use udf_file_free for that.
   */
-  udf_dirent_t *udf_get_root (udf_t *p_udf, bool b_any_partition, 
+  udf_dirent_t *udf_get_root (udf_t *p_udf, bool b_any_partition,
                               partition_num_t i_partition);
-  
+
   /**
    * Gets the Volume Identifier string, in 8bit unicode (latin-1)
    * psz_volid, place to put the string
    * i_volid, size of the buffer psz_volid points to
    * returns the size of buffer needed for all data
    */
-  int udf_get_volume_id(udf_t *p_udf, /*out*/ char *psz_volid,  
+  int udf_get_volume_id(udf_t *p_udf, /*out*/ char *psz_volid,
                         unsigned int i_volid);
-  
+
   /**
    * Gets the Volume Set Identifier, as a 128-byte dstring (not decoded)
    * WARNING This is not a null terminated string
    * volsetid, place to put the data
-   * i_volsetid, size of the buffer psz_volsetid points to 
+   * i_volsetid, size of the buffer psz_volsetid points to
    * the buffer should be >=128 bytes to store the whole volumesetidentifier
    * returns the size of the available volsetid information (128)
    * or 0 on error
@@ -140,20 +140,20 @@ extern "C" {
    * returns the size of buffer needed for all data
    * A call to udf_get_root() should have been issued before this call
    */
-  int udf_get_logical_volume_id(udf_t *p_udf, /*out*/ char *psz_logvolid,  
+  int udf_get_logical_volume_id(udf_t *p_udf, /*out*/ char *psz_logvolid,
                         unsigned int i_logvolid);
 
-  /*!
-    Return a file pointer matching psz_name. 
+  /**
+    Return a file pointer matching psz_name.
   */
   udf_dirent_t *udf_fopen(udf_dirent_t *p_udf_root, const char *psz_name);
-  
-  /*! udf_mode_string - fill in string PSZ_STR with an ls-style ASCII
+
+  /** udf_mode_string - fill in string PSZ_STR with an ls-style ASCII
     representation of the i_mode. PSZ_STR is returned.
 
     10 characters are stored in PSZ_STR; a terminating null byte is added.
     The characters stored in PSZ_STR are:
-    
+
     0   File type.  'd' for directory, 'c' for character
         special, 'b' for block special, 'm' for multiplex,
         'l' for symbolic link, 's' for socket, 'p' for fifo,
@@ -187,7 +187,7 @@ extern "C" {
 
     char *udf_mode_string (mode_t i_mode, char *psz_str);
 
-    bool udf_get_lba(const udf_file_entry_t *p_udf_fe, 
+    bool udf_get_lba(const udf_file_entry_t *p_udf_fe,
                      /*out*/ uint32_t *start, /*out*/ uint32_t *end);
 
     /**

--- a/include/cdio/udf_time.h
+++ b/include/cdio/udf_time.h
@@ -15,7 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/*!
+/**
  * \file udf_time.h
  *
  * \brief UDF time conversion and access files.
@@ -38,38 +38,38 @@ struct timespec {
 extern "C" {
 #endif /* __cplusplus */
 
-  /*!
+  /**
     Return the access time of the file.
   */
   time_t udf_get_access_time(const udf_dirent_t *p_udf_dirent);
 
-  /*!
+  /**
     Return the attribute (most recent create or access) time of the file
   */
   time_t udf_get_attribute_time(const udf_dirent_t *p_udf_dirent);
 
-  /*!
+  /**
     Return the modification time of the file.
   */
   time_t udf_get_modification_time(const udf_dirent_t *p_udf_dirent);
 
-  /*!
+  /**
     Return the access timestamp of the file
   */
   udf_timestamp_t *udf_get_access_timestamp(const udf_dirent_t *p_udf_dirent);
 
-  /*!
+  /**
     Return the modification timestamp of the file
   */
   udf_timestamp_t *udf_get_modification_timestamp(const udf_dirent_t
 						  *p_udf_dirent);
 
-  /*!
+  /**
     Return the attr timestamp of the file
   */
   udf_timestamp_t *udf_get_attr_timestamp(const udf_dirent_t *p_udf_dirent);
 
-  /*!
+  /**
     Convert a UDF timestamp to a time_t. If microseconds are desired,
     use dest_usec. The return value is the same as dest. */
   time_t *udf_stamp_to_time(time_t *dest, long int *dest_usec,

--- a/include/cdio/util.h
+++ b/include/cdio/util.h
@@ -20,7 +20,7 @@
 #ifndef CDIO_UTIL_H_
 #define CDIO_UTIL_H_
 
-/*!
+/**
    \file util.h
    \brief Miscellaneous utility functions.
 
@@ -66,7 +66,7 @@ _cdio_len2blocks (uint32_t i_len, uint16_t i_blocksize)
 }
 
 
-/*! free() and NULL out p_obj it is not already null. */
+/** free() and NULL out p_obj it is not already null. */
 #define CDIO_FREE_IF_NOT_NULL(p_obj) \
   if (NULL != p_obj) { free(p_obj); p_obj=NULL; };
 
@@ -105,7 +105,7 @@ _cdio_memdup (const void *mem, size_t count);
 char *
 _cdio_strdup_upper (const char str[]);
 
-/*! Duplicate path and make it platform compliant. Typically needed for
+/** Duplicate path and make it platform compliant. Typically needed for
     MinGW/MSYS where a "/c/..." path must be translated to "c:/..." for
     use with fopen(), etc. Returned string must be freed by the caller
     using cdio_free(). */
@@ -124,7 +124,7 @@ _cdio_strsplit(const char str[], char delim);
 uint8_t cdio_to_bcd8(uint8_t n);
 uint8_t cdio_from_bcd8(uint8_t p);
 
-/*!  cdio_realpath() same as POSIX.1-2001 realpath if that's
+/**  cdio_realpath() same as POSIX.1-2001 realpath if that's
 around. If not we do poor-man's simulation of that behavior.  */
 char *cdio_realpath (const char *psz_src, char *psz_dst);
 

--- a/include/cdio/version.h.in
+++ b/include/cdio/version.h.in
@@ -4,13 +4,13 @@
  *  number (@LIBCDIO_VERSION_NUM@) and OS build name.
  */
 
-/*! CDIO_VERSION is a C-Preprocessor macro of a string that shows what
+/** CDIO_VERSION is a C-Preprocessor macro of a string that shows what
     version is used.  cdio_version_string has the same value, but it is a
     constant variable that can be accessed at run time. */
 #define CDIO_VERSION "@VERSION@ @build@"
 extern const char *cdio_version_string; /**< = CDIO_VERSION */
 
-/*! LIBCDIO_VERSION_NUM is a C-Preprocessor macro that can be used for
+/** LIBCDIO_VERSION_NUM is a C-Preprocessor macro that can be used for
     testing in the C preprocessor. libcdio_version_num has the same
     value, but it is a constant variable that can be accessed at run
     time.  */

--- a/include/cdio/xa.h
+++ b/include/cdio/xa.h
@@ -21,7 +21,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/*!
+/**
    \file xa.h
    \brief Things related to the ISO-9660 XA (Extended Attributes) format
 
@@ -37,7 +37,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-  /*! An enumeration for some of the XA_* \#defines below. This isn't
+  /** An enumeration for some of the XA_* \#defines below. This isn't
     really an enumeration one would really use in a program it is to
     be helpful in debuggers where wants just to refer to the XA_*
     names and get something.
@@ -79,7 +79,7 @@ extern const char ISO_XA_MARKER_STRING[sizeof("CD-XA001")-1];
 
 #define ISO_XA_MARKER_STRING    "CD-XA001"
 
-/*! \brief "Extended Architecture" according to the Philips Yellow Book.
+/** \brief "Extended Architecture" according to the Philips Yellow Book.
 
 CD-ROM EXtended Architecture is a modification to the CD-ROM
 specification that defines two new types of sectors.  CD-ROM XA was
@@ -112,12 +112,12 @@ typedef struct iso9660_xa_s
 } GNUC_PACKED iso9660_xa_t;
 
 
-  /*!
+  /**
     Returns POSIX mode bitstring for a given file.
   */
   posix_mode_t iso9660_get_posix_filemode_from_xa(uint16_t i_perms);
 
-/*!
+/**
   Returns a string interpreting the extended attribute xa_attr.
   For example:
   \verbatim
@@ -148,7 +148,7 @@ typedef struct iso9660_xa_s
 const char *
 iso9660_get_xa_attr_str (uint16_t xa_attr);
 
-/*!
+/**
   Allocates and initializes a new iso9600_xa_t variable and returns
   it. The caller must free the returned result using iso9660_xa_free().
 
@@ -158,7 +158,7 @@ iso9660_xa_t *
 iso9660_xa_init (iso9660_xa_t *_xa, uint16_t uid, uint16_t gid, uint16_t attr,
                  uint8_t filenum);
 
-/*!
+/**
   Frees the passed iso9600_xa_t structure.
 
   @see iso9660_xa

--- a/lib/cdio++/devices.cpp
+++ b/lib/cdio++/devices.cpp
@@ -27,7 +27,7 @@
 #include <cdio/cdio.h>
 #include <cdio++/cdio.hpp>
 
-/*!
+/**
   Close media tray in CD drive if there is a routine to do so.
 
   @param psz_drive the name of CD-ROM to be closed.
@@ -41,7 +41,7 @@ void closeTray (const char *psz_drive, /*in/out*/ driver_id_t &driver_id)
   possible_throw_device_exception(drc);
 }
 
-/*!
+/**
   Close media tray in CD drive if there is a routine to do so.
 
   @param psz_drive the name of CD-ROM to be closed. If omitted or
@@ -53,7 +53,7 @@ void closeTray (const char *psz_drive)
   closeTray(psz_drive, driver_id);
 }
 
-/*!
+/**
   Get a string describing driver_id.
 
   @param driver_id the driver you want the description for
@@ -65,7 +65,7 @@ driverDescribe (driver_id_t driver_id)
   return cdio_driver_describe(driver_id);
 }
 
-/*!
+/**
   Eject media in CD drive if there is a routine to do so.
 
   If the CD is ejected, object is destroyed.
@@ -77,7 +77,7 @@ ejectMedia (const char *psz_drive)
   possible_throw_device_exception(drc);
 }
 
-/*!
+/**
   Free device list returned by GetDevices
 
   @param device_list list returned by GetDevices
@@ -91,7 +91,7 @@ freeDeviceList (char * device_list[])
   cdio_free_device_list(device_list);
 }
 
-/*!
+/**
   Return a string containing the default CD device if none is specified.
   if p_driver_id is DRIVER_UNKNOWN or DRIVER_DEVICE
   then find a suitable one set the default device for that.
@@ -104,7 +104,7 @@ getDefaultDevice(/*in/out*/ driver_id_t &driver_id)
   return cdio_get_default_device_driver(&driver_id);
 }
 
-/*! Return an array of device names. If you want a specific
+/** Return an array of device names. If you want a specific
   devices for a driver, give that device. If you want hardware
   devices, give DRIVER_DEVICE and if you want all possible devices,
   image drivers and hardware drivers give DRIVER_UNKNOWN.
@@ -121,7 +121,7 @@ getDevices(driver_id_t driver_id)
   return cdio_get_devices(driver_id);
 }
 
-/*! Like GetDevices above, but we may change the p_driver_id if we
+/** Like GetDevices above, but we may change the p_driver_id if we
   were given DRIVER_DEVICE or DRIVER_UNKNOWN. This is because
   often one wants to get a drive name and then *open* it
   afterwards. Giving the driver back facilitates this, and speeds
@@ -134,7 +134,7 @@ getDevices (driver_id_t &driver_id)
   return cdio_get_devices_ret(&driver_id);
 }
 
-/*!
+/**
   Get an array of device names in search_devices that have at least
   the capabilities listed by the capabities parameter.  If
   search_devices is NULL, then we'll search all possible CD drives.
@@ -158,7 +158,7 @@ getDevices(/*in*/ char *ppsz_search_devices[],
   return cdio_get_devices_with_cap(ppsz_search_devices, capabilities, b_any);
 }
 
-/*!
+/**
   Like GetDevices above but we return the driver we found
   as well. This is because often one wants to search for kind of drive
   and then *open* it afterwards. Giving the driver back facilitates this,
@@ -173,14 +173,14 @@ getDevices(/*in*/ char* ppsz_search_devices[],
 				       b_any, &driver_id);
 }
 
-/*! Return true if we Have driver for driver_id */
+/** Return true if we Have driver for driver_id */
 bool
 haveDriver (driver_id_t driver_id)
 {
   return cdio_have_driver(driver_id);
 }
 
-/*!
+/**
 
 Determine if bin_name is the bin file part of  a CDRWIN CD disk image.
 
@@ -193,7 +193,7 @@ char *isBinFile(const char *psz_bin_name)
   return cdio_is_binfile(psz_bin_name);
 }
 
-/*!
+/**
     Determine if cue_name is the cue sheet for a CDRWIN CD disk image.
 
     @return corresponding BIN file if cue_name is a CDRWIN cue file or
@@ -205,7 +205,7 @@ isCueFile(const char *psz_cue_name)
   return cdio_is_cuefile(psz_cue_name);
 }
 
-/*!
+/**
     Determine if psz_source refers to a real hardware CD-ROM.
 
     @param psz_source location name of object
@@ -220,7 +220,7 @@ isDevice(const char *psz_source, driver_id_t driver_id)
   return cdio_is_device(psz_source, driver_id);
 }
 
-/*!
+/**
     Determine if psz_nrg is a Nero CD disk image.
 
     @param psz_nrg location of presumed NRG image file.
@@ -233,7 +233,7 @@ isNero(const char *psz_nrg)
   return cdio_is_nrg(psz_nrg);
 }
 
-/*!
+/**
   Determine if psz_toc is a TOC file for a cdrdao CD disk image.
 
   @param psz_toc location of presumed TOC image file.

--- a/lib/cdio++/iso9660.cpp
+++ b/lib/cdio++/iso9660.cpp
@@ -26,7 +26,7 @@
 
 #include <cdio++/iso9660.hpp>
 
-/*!
+/**
   Given a directory pointer, find the filesystem entry that contains
   lsn and return information about it.
 
@@ -39,7 +39,7 @@ ISO9660::FS::find_lsn(lsn_t i_lsn)
   return new Stat(iso9660_find_fs_lsn(p_cdio, i_lsn));
 }
 
-/*!
+/**
   Read the Primary Volume Descriptor for a CD.
   True is returned if read, and false if there was an error.
 */
@@ -54,7 +54,7 @@ ISO9660::FS::read_pvd ()
   return (PVD *) NULL;
 }
 
-/*!
+/**
   Read the Super block of an ISO 9660 image. This is the
   Primary Volume Descriptor (PVD) and perhaps a Supplemental Volume
   Descriptor if (Joliet) extensions are acceptable.
@@ -65,7 +65,7 @@ ISO9660::FS::read_superblock (iso_extension_mask_t iso_extension_mask)
   return iso9660_fs_read_superblock (p_cdio, iso_extension_mask);
 }
 
-/*! Read psz_path (a directory) and return a list of iso9660_stat_t
+/** Read psz_path (a directory) and return a list of iso9660_stat_t
   pointers for the files inside that directory. The caller must free the
   returned result.
 */
@@ -87,7 +87,7 @@ ISO9660::FS::readdir (const char psz_path[], stat_vector_t& stat_vector)
   }
 }
 
-/*! Close previously opened ISO 9660 image and free resources
+/** Close previously opened ISO 9660 image and free resources
   associated with the image. Call this when done using using an ISO
   9660 image.
 
@@ -102,7 +102,7 @@ ISO9660::IFS::close()
   return true;
 }
 
-/*!
+/**
   Given a directory pointer, find the filesystem entry that contains
   lsn and return information about it.
 
@@ -115,7 +115,7 @@ ISO9660::IFS::find_lsn(lsn_t i_lsn)
   return new Stat(iso9660_ifs_find_lsn(p_iso9660, i_lsn));
 }
 
-/*!
+/**
   Return the Joliet level recognized.
 */
 uint8_t
@@ -124,7 +124,7 @@ ISO9660::IFS::get_joliet_level()
   return iso9660_ifs_get_joliet_level(p_iso9660);
 }
 
-/*!
+/**
   Return true if ISO 9660 image has extended attributes (XA).
 */
 bool
@@ -133,7 +133,7 @@ ISO9660::IFS::is_xa ()
   return iso9660_ifs_is_xa (p_iso9660);
 }
 
-/*! Open an ISO 9660 image for "fuzzy" reading. This means that we
+/** Open an ISO 9660 image for "fuzzy" reading. This means that we
   will try to guess various internal offset based on internal
   checks. This may be useful when trying to read an ISO 9660 image
   contained in a file format that libiso9660 doesn't know natively
@@ -154,7 +154,7 @@ ISO9660::IFS::open_fuzzy (const char *psz_path,
   return true;
 }
 
-/*! Read the Primary Volume Descriptor for an ISO 9660 image.  A
+/** Read the Primary Volume Descriptor for an ISO 9660 image.  A
   PVD object is returned if read, and NULL if there was an error.
 */
 ISO9660::PVD *
@@ -168,7 +168,7 @@ ISO9660::IFS::read_pvd ()
   return (PVD *) NULL;
 }
 
-/*!
+/**
   Read the Super block of an ISO 9660 image but determine framesize
   and datastart and a possible additional offset. Generally here we are
   not reading an ISO 9660 image but a CD-Image which contains an ISO 9660
@@ -183,7 +183,7 @@ ISO9660::IFS::read_superblock (iso_extension_mask_t iso_extension_mask,
   return iso9660_ifs_read_superblock (p_iso9660, iso_extension_mask);
 }
 
-/*!
+/**
   Read the Super block of an ISO 9660 image but determine framesize
   and datastart and a possible additional offset. Generally here we are
   not reading an ISO 9660 image but a CD-Image which contains an ISO 9660
@@ -211,7 +211,7 @@ ISO9660::PVD::get_pvd_block_size()
   return iso9660_get_pvd_block_size(&pvd);
 }
 
-/*!
+/**
   Return the PVD's preparer ID.
   NULL is returned if there is some problem in getting this.
 */
@@ -221,7 +221,7 @@ ISO9660::PVD::get_preparer_id()
   return iso9660_get_preparer_id(&pvd);
 }
 
-/*!
+/**
   Return the PVD's publisher ID.
   NULL is returned if there is some problem in getting this.
 */
@@ -248,7 +248,7 @@ ISO9660::PVD::get_pvd_type() {
   return iso9660_get_pvd_type(&pvd);
 }
 
-/*! Return the primary volume id version number (of pvd).
+/** Return the primary volume id version number (of pvd).
   If there is an error 0 is returned.
 */
 int
@@ -257,7 +257,7 @@ ISO9660::PVD::get_pvd_version()
   return iso9660_get_pvd_version(&pvd);
 }
 
-/*! Return the LSN of the root directory for pvd.
+/** Return the LSN of the root directory for pvd.
   If there is an error CDIO_INVALID_LSN is returned.
 */
 lsn_t
@@ -266,7 +266,7 @@ ISO9660::PVD::get_root_lsn()
   return iso9660_get_root_lsn(&pvd);
 }
 
-/*!
+/**
   Return the PVD's system ID.
   NULL is returned if there is some problem in getting this.
 */
@@ -276,7 +276,7 @@ ISO9660::PVD::get_system_id()
   return iso9660_get_system_id(&pvd);
 }
 
-/*!
+/**
   Return the PVD's volume ID.
   NULL is returned if there is some problem in getting this.
 */
@@ -286,7 +286,7 @@ ISO9660::PVD::get_volume_id()
   return iso9660_get_volume_id(&pvd);
 }
 
-/*!
+/**
   Return the PVD's volumeset ID.
   NULL is returned if there is some problem in getting this.
 */

--- a/lib/driver/FreeBSD/freebsd.c
+++ b/lib/driver/FreeBSD/freebsd.c
@@ -108,7 +108,7 @@ cdio_is_cdrom(char *drive, char *mnttype)
   return cdio_is_cdrom_freebsd_ioctl(drive, mnttype);
 }
 
-/*!
+/**
    Reads i_blocks of audio sectors from cd device into data starting from lsn.
    Returns 0 if no error.
  */
@@ -133,7 +133,7 @@ read_audio_sectors_freebsd (void *p_user_data, void *p_buf, lsn_t i_lsn,
   return DRIVER_OP_ERROR;
 }
 
-/*!
+/**
    Reads a single mode2 sector from cd device into data starting
    from i_lsn. Returns 0 if no error.
  */
@@ -157,7 +157,7 @@ read_mode2_sector_freebsd (void *p_user_data, void *data, lsn_t i_lsn,
   return DRIVER_OP_ERROR;
 }
 
-/*!
+/**
    Reads i_blocks of mode2 sectors from cd device into data starting
    from lsn.
  */
@@ -189,7 +189,7 @@ read_mode2_sectors_freebsd (void *p_user_data, void *p_data, lsn_t i_lsn,
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
    Return the size of the CD in logical block address (LBA) units.
   @return the lsn. On error return CDIO_INVALID_LSN.
  */
@@ -214,7 +214,7 @@ get_disc_last_lsn_freebsd (void *p_obj)
   return DRIVER_OP_ERROR;
 }
 
-/*!
+/**
   Set the arg "key" with "value" in the source device.
   Currently "source" and "access-mode" are valid keys.
   "source" sets the source device in I/O operations
@@ -262,7 +262,7 @@ set_speed_freebsd (void *p_user_data, int i_speed)
 #endif
 }
 
-/*!
+/**
   Read and cache the CD's Track Table of Contents and track info.
   Return false if unsuccessful;
 */
@@ -313,7 +313,7 @@ read_toc_freebsd (void *p_user_data)
   return true;
 }
 
-/*!
+/**
   Get the volume of an audio CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -327,7 +327,7 @@ audio_get_volume_freebsd (void *p_user_data,
   return ioctl(p_env->gen.fd, CDIOCGETVOL, p_volume);
 }
 
-/*!
+/**
   Pause playing CD through analog output
 
   @param p_cdio the CD object to be acted upon.
@@ -340,7 +340,7 @@ audio_pause_freebsd (void *p_user_data)
   return ioctl(p_env->gen.fd, CDIOCPAUSE);
 }
 
-/*!
+/**
   Playing starting at given MSF through analog output
 
   @param p_cdio the CD object to be acted upon.
@@ -363,7 +363,7 @@ audio_play_msf_freebsd (void *p_user_data, msf_t *p_start_msf,
   return ioctl(p_env->gen.fd, CDIOCPLAYMSF, &freebsd_play_msf);
 }
 
-/*!
+/**
   Playing CD through analog output at the desired track and index
 
   @param p_user_data the CD object to be acted upon.
@@ -396,7 +396,7 @@ audio_play_track_index_freebsd (void *p_user_data,
 
 }
 
-/*!
+/**
   Read Audio Subchannel information
 
   @param p_user_data the CD object to be acted upon.
@@ -437,7 +437,7 @@ audio_read_subchannel_freebsd (void *p_user_data,
 }
 #endif
 
-/*!
+/**
   Resume playing an audio CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -450,7 +450,7 @@ audio_resume_freebsd (void *p_user_data)
   return ioctl(p_env->gen.fd, CDIOCRESUME, 0);
 }
 
-/*!
+/**
   Set the volume of an audio CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -464,7 +464,7 @@ audio_set_volume_freebsd (void *p_user_data,
   return ioctl(p_env->gen.fd, CDIOCSETVOL, p_volume);
 }
 
-/*!
+/**
   Eject media. Return 1 if successful, 0 otherwise.
  */
 static int
@@ -486,7 +486,7 @@ eject_media_freebsd (void *p_user_data)
   return 0;
 }
 
-/*!
+/**
   Stop playing an audio CD.
 
   @param p_user_data the CD object to be acted upon.
@@ -499,7 +499,7 @@ audio_stop_freebsd (void *p_user_data)
   return ioctl(p_env->gen.fd, CDIOCSTOP);
 }
 
-/*!
+/**
   Produce a text composed from the system SCSI address tuple according to
   habits of Linux 2.4 and 2.6 :  "Bus,Host,Channel,Target,Lun" and store
   it in generic_img_private_t.scsi_tuple.
@@ -556,7 +556,7 @@ is_mmc_supported(void *user_data)
 }
 
 
-/*!
+/**
   Return the value associated with the key "arg".
 */
 static const char *
@@ -589,7 +589,7 @@ get_arg_freebsd (void *user_data, const char key[])
   return NULL;
 }
 
-/*!
+/**
   Return the media catalog number MCN.
 
   Note: string is malloc'd so caller should free() then returned
@@ -616,7 +616,7 @@ get_mcn_freebsd (const void *p_user_data) {
   return NULL;
 }
 
-/*!
+/**
   Return the international standard recording code ISRC.
 
   Note: string is malloc'd so caller should free() then returned
@@ -664,7 +664,7 @@ get_drive_cap_freebsd (const void *p_user_data,
   }
 }
 
-/*!
+/**
   Run a SCSI MMC command.
 
   p_user_data   internal CD structure.
@@ -704,7 +704,7 @@ run_mmc_cmd_freebsd( void *p_user_data, unsigned int i_timeout_ms,
   return DRIVER_OP_ERROR;
 }
 
-/*!
+/**
   Get format of track.
 
   FIXME: We're just guessing this from the GNU/Linux code.
@@ -737,7 +737,7 @@ get_track_format_freebsd(void *p_user_data, track_t i_track)
 
 }
 
-/*!
+/**
   Return true if we have XA data (green, mode2 form1) or
   XA data (green, mode2 form2). That is track begins:
   sync - header - subheader
@@ -761,7 +761,7 @@ get_track_green_freebsd(void *user_data, track_t i_track)
   return ((p_env->tocent[i_track-FIRST_TRACK_NUM].entry.control & 2) != 0);
 }
 
-/*!
+/**
   Return the starting LSN track number
   i_track in obj.  Track numbers start at 1.
   The "leadout" track is specified either by
@@ -786,7 +786,7 @@ get_track_lba_freebsd(void *user_data, track_t i_track)
 
 #endif /* HAVE_FREEBSD_CDROM */
 
-/*!
+/**
   Return an array of strings giving possible CD devices.
  */
 char **
@@ -859,7 +859,7 @@ cdio_get_devices_freebsd (void)
 #endif /*HAVE_FREEBSD_CDROM*/
 }
 
-/*!
+/**
   Return a string containing the default CD device if none is specified.
  */
 char *
@@ -916,7 +916,7 @@ cdio_get_default_device_freebsd(void)
 #endif /*HAVE_FREEBSD_CDROM*/
 }
 
-/*!
+/**
   Close tray on CD-ROM.
 
   @param psz_device the CD-ROM drive to be closed.
@@ -941,7 +941,7 @@ close_tray_freebsd (const char *psz_device)
 #endif /*HAVE_FREEBSD_CDROM*/
 }
 
-/*! Find out if media has changed since the last call.  @param
+/** Find out if media has changed since the last call.  @param
   p_user_data the environment of the CD object to be acted upon.
   @return 1 if media has changed since last call, 0 if not. Error
   return codes are the same as driver_return_code_t
@@ -1094,7 +1094,7 @@ static int freebsd_dev_lock(int dev_fd, char *devname,
 
 #endif /*HAVE_FREEBSD_CDROM*/
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.
@@ -1106,7 +1106,7 @@ cdio_open_freebsd (const char *psz_source_name)
 }
 
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.

--- a/lib/driver/FreeBSD/freebsd.h
+++ b/lib/driver/FreeBSD/freebsd.h
@@ -33,7 +33,7 @@
 #include "cdio_assert.h"
 #include "cdio_private.h"
 
-/*!
+/**
   For ioctl access /dev/acd0c is preferred over /dev/cd0c.
   For cam access /dev/cd0c is preferred. DEFAULT_CDIO_DEVICE and
   DEFAULT_FREEBSD_AM should be consistent.
@@ -168,13 +168,13 @@ char *get_mcn_freebsd_ioctl (const _img_private_t *p_env);
 
 void free_freebsd_cam (void *obj);
 
-/*!
+/**
    Using the ioctl method, r nblocks of audio sectors from cd device
    into data starting from lsn.  Returns 0 if no error.
  */
 int  read_audio_sectors_freebsd_ioctl (_img_private_t *env, void *data,
 				       lsn_t lsn, unsigned int nblocks);
-/*!
+/**
    Using the CAM method, reads nblocks of mode2 sectors from
    cd device using into data starting from lsn.  Returns 0 if no
    error.
@@ -182,7 +182,7 @@ int  read_audio_sectors_freebsd_ioctl (_img_private_t *env, void *data,
 int  read_mode2_sector_freebsd_cam (_img_private_t *env, void *data,
 				    lsn_t lsn, bool b_form2);
 
-/*!
+/**
    Using the ioctl method, reads nblocks of mode2 sectors from
    cd device using into data starting from lsn.  Returns 0 if no
    error.
@@ -190,7 +190,7 @@ int  read_mode2_sector_freebsd_cam (_img_private_t *env, void *data,
 int  read_mode2_sector_freebsd_ioctl (_img_private_t *env, void *data,
 				      lsn_t lsn, bool b_form2);
 
-/*!
+/**
    Using the CAM method, reads nblocks of mode2 form2 sectors from
    cd device using into data starting from lsn.  Returns 0 if no
    error.
@@ -203,7 +203,7 @@ int  read_mode2_sectors_freebsd_cam (_img_private_t *env, void *buf,
 
 bool read_toc_freebsd_ioctl (_img_private_t *env);
 
-/*!
+/**
   Run a SCSI MMC command.
 
   p_user_data   internal CD structure.
@@ -226,7 +226,7 @@ int run_mmc_cmd_freebsd_cam( void *p_user_data,
 			     unsigned int i_buf,
 			     /*in/out*/ void *p_buf );
 
-/*!
+/**
    Return the size of the CD in logical block address (LBA) units.
  */
 lsn_t get_disc_last_lsn_freebsd_ioctl (_img_private_t *_obj);

--- a/lib/driver/FreeBSD/freebsd_cam.c
+++ b/lib/driver/FreeBSD/freebsd_cam.c
@@ -33,7 +33,7 @@
    complete. */
 #define DEFAULT_TIMEOUT_MSECS 10000
 
-/*!
+/**
   Run a SCSI MMC command.
 
   p_user_data   internal CD structure.
@@ -189,7 +189,7 @@ read_mode2_sector_freebsd_cam (_img_private_t *p_env, void *data, lsn_t lsn,
   }
 }
 
-/*!
+/**
    Reads nblocks of mode2 sectors from cd device into data starting
    from lsn.
    Returns 0 if no error.
@@ -238,7 +238,7 @@ read_mode2_sectors_freebsd_cam (_img_private_t *p_env, void *p_buf,
   }
 }
 
-/*!
+/**
   Eject media in CD-ROM drive. Return DRIVER_OP_SUCCESS if successful,
   DRIVER_OP_ERROR on error.
  */

--- a/lib/driver/FreeBSD/freebsd_ioctl.c
+++ b/lib/driver/FreeBSD/freebsd_ioctl.c
@@ -101,7 +101,7 @@ cdio_is_cdrom_freebsd_ioctl(char *drive, char *mnttype)
 
 }
 
-/*!
+/**
    Reads a single mode2 sector from cd device into data starting from lsn.
    Returns 0 if no error.
  */
@@ -123,7 +123,7 @@ read_audio_sectors_freebsd_ioctl (_img_private_t *_obj, void *data, lsn_t lsn,
   return 0;
 }
 
-/*!
+/**
    Reads a single mode2 sector from cd device into data starting
    from lsn. Returns 0 if no error.
  */
@@ -145,7 +145,7 @@ read_mode2_sector_freebsd_ioctl (_img_private_t *p_env, void *data, lsn_t lsn,
   return 0;
 }
 
-/*!
+/**
    Return the size of the CD in logical block address (LBA) units.
  */
 lsn_t
@@ -167,7 +167,7 @@ get_disc_last_lsn_freebsd_ioctl (_img_private_t *p_obj)
   return size;
 }
 
-/*!
+/**
   Eject media in CD-ROM drive. Return DRIVER_OP_SUCCESS if successful,
   DRIVER_OP_ERROR on error.
  */
@@ -188,7 +188,7 @@ eject_media_freebsd_ioctl (_img_private_t *p_env)
   return ret;
 }
 
-/*!
+/**
   Return the media catalog number MCN.
 
   Note: string is malloc'd so caller should free() then returned
@@ -223,7 +223,7 @@ get_mcn_freebsd_ioctl (const _img_private_t *p_env) {
     return NULL;
 }
 
-/*!
+/**
   Get format of track.
 
   FIXME: We're just guessing this from the GNU/Linux code.
@@ -257,7 +257,7 @@ get_track_format_freebsd_ioctl(const _img_private_t *p_env, track_t i_track)
     return TRACK_FORMAT_AUDIO;
 }
 
-/*!
+/**
   Return true if we have XA data (green, mode2 form1) or
   XA data (green, mode2 form2). That is track begins:
   sync - header - subheader

--- a/lib/driver/MSWindows/aspi32.c
+++ b/lib/driver/MSWindows/aspi32.c
@@ -174,7 +174,7 @@ have_aspi( HMODULE *hASPI,
   return true;
 }
 
-/*!
+/**
   Get disc type associated with cd object.
 */
 discmode_t
@@ -352,7 +352,7 @@ is_cdrom_aspi(const char drive_letter)
   return NULL;
 }
 
-/*!
+/**
   Initialize CD device.
  */
 bool
@@ -471,7 +471,7 @@ init_aspi (_img_private_t *env)
   return false;
 }
 
-/*!
+/**
   Run a SCSI MMC command.
 
   env           private CD structure
@@ -554,7 +554,7 @@ run_mmc_cmd_aspi( void *p_user_data, unsigned int i_timeout_ms,
 }
 
 
-/*!
+/**
    Reads nblocks sectors from cd device into data starting from lsn.
    Returns 0 if no error.
  */
@@ -616,7 +616,7 @@ read_sectors_aspi (_img_private_t *p_env, void *data, lsn_t lsn,
                           &cdb, SCSI_MMC_DATA_READ, i_buf*nblocks, data);
 }
 
-/*!
+/**
    Reads an audio device into data starting from lsn.
    Returns 0 if no error.
  */
@@ -631,7 +631,7 @@ read_audio_sectors_aspi (_img_private_t *p_env, void *data, lsn_t lsn,
   return 0;
 }
 
-/*!
+/**
    Reads a single mode2 sector from cd device into data starting
    from lsn. Returns 0 if no error.
  */
@@ -645,7 +645,7 @@ read_mode2_sector_aspi (_img_private_t *p_env, void *data, lsn_t lsn,
                                1);
 }
 
-/*!
+/**
    Reads a single mode2 sector from cd device into data starting
    from lsn. Returns 0 if no error.
  */
@@ -656,7 +656,7 @@ read_mode1_sector_aspi (_img_private_t *p_env, void *data, lsn_t lsn,
   return read_sectors_aspi(p_env, data, lsn, CDIO_MMC_READ_TYPE_MODE1, 1);
 }
 
-/*!
+/**
   Read and cache the CD's Track Table of Contents and track info.
   Return true if successful or false if an error.
 */
@@ -737,7 +737,7 @@ read_toc_aspi (_img_private_t *p_env)
 
 /* Eject media will eventually get removed from _cdio_win32.c */
 #if 0
-/*!
+/**
   Eject media. Return 1 if successful, 0 otherwise.
  */
 int
@@ -776,7 +776,7 @@ wnaspi32_eject_media (void *user_data) {
 }
 #endif
 
-/*!
+/**
   Get format of track.
 */
 track_format_t

--- a/lib/driver/MSWindows/aspi32.h
+++ b/lib/driver/MSWindows/aspi32.h
@@ -44,20 +44,20 @@
 
 #define SS_INVALID_SRB            0xE0  // Invalid parameter set in SRB
 #define SS_OLD_MANAGER            0xE1  // ASPI manager doesn't support Windows
-#define SS_BUFFER_ALIGN           0xE1  // Buffer not aligned (replaces 
+#define SS_BUFFER_ALIGN           0xE1  // Buffer not aligned (replaces
                                         // OLD_MANAGER in Win32)
 #define SS_ILLEGAL_MODE           0xE2  // Unsupported Windows mode
 #define SS_NO_ASPI                0xE3  // No ASPI managers resident
 #define SS_FAILED_INIT            0xE4  // ASPI for windows failed init
-#define SS_ASPI_IS_BUSY           0xE5  // No resources available to execute 
+#define SS_ASPI_IS_BUSY           0xE5  // No resources available to execute
                                         // cmd
 #define SS_BUFFER_TOO_BIG         0xE6  // Buffer size to big to handle!
-#define SS_MISMATCHED_COMPONENTS  0xE7  // The DLLs/EXEs of ASPI don't version 
+#define SS_MISMATCHED_COMPONENTS  0xE7  // The DLLs/EXEs of ASPI don't version
                                         // check
 #define SS_NO_ADAPTERS            0xE8  // No host adapters to manage
-#define SS_INSUFFICIENT_RESOURCES 0xE9  // Couldn't allocate resources needed 
+#define SS_INSUFFICIENT_RESOURCES 0xE9  // Couldn't allocate resources needed
                                         // to init
-#define SS_ASPI_IS_SHUTDOWN       0xEA  // Call came to ASPI after 
+#define SS_ASPI_IS_SHUTDOWN       0xEA  // Call came to ASPI after
                                         // PROCESS_DETACH
 #define SS_BAD_INSTALL            0xEB  // The DLL or other components are installed wrong
 
@@ -164,12 +164,12 @@ typedef struct                     // Offset
 }
 SRB_HAInquiry;
 
-/*! 
+/**
   Get disc type associated with cd object.
 */
 discmode_t get_discmode_aspi (_img_private_t *p_env);
 
-/*!
+/**
   Return the the kind of drive capabilities of device.
 
   Note: string is malloc'd so caller should free() then returned
@@ -178,63 +178,62 @@ discmode_t get_discmode_aspi (_img_private_t *p_env);
  */
 char * get_mcn_aspi (const _img_private_t *env);
 
-/*!  
-  Get the format (XA, DATA, AUDIO) of a track. 
+/**
+  Get the format (XA, DATA, AUDIO) of a track.
 */
-track_format_t get_track_format_aspi(const _img_private_t *env, 
-				     track_t i_track); 
+track_format_t get_track_format_aspi(const _img_private_t *env,
+				     track_t i_track);
 
-/*!
+/**
   Initialize internal structures for CD device.
  */
 bool init_aspi (_img_private_t *env);
 
 const char *is_cdrom_aspi(const char drive_letter);
 
-/*!
+/**
    Reads an audio device using the DeviceIoControl method into data
    starting from lsn.  Returns 0 if no error.
  */
-int read_audio_sectors_aspi (_img_private_t *obj, void *data, lsn_t lsn, 
+int read_audio_sectors_aspi (_img_private_t *obj, void *data, lsn_t lsn,
 			     unsigned int nblocks);
-/*!
+/**
    Reads a single mode1 sector using the DeviceIoControl method into
    data starting from lsn. Returns 0 if no error.
  */
-int read_mode1_sector_aspi (_img_private_t *env, void *data, 
+int read_mode1_sector_aspi (_img_private_t *env, void *data,
 			    lsn_t lsn, bool b_form2);
-/*!
+/**
    Reads a single mode2 sector from cd device into data starting
-   from lsn. Returns 0 if no error. 
+   from lsn. Returns 0 if no error.
  */
-int read_mode2_sector_aspi (_img_private_t *env, void *data, lsn_t lsn, 
+int read_mode2_sector_aspi (_img_private_t *env, void *data, lsn_t lsn,
 			    bool b_form2);
 
-/*! 
+/**
   Read and cache the CD's Track Table of Contents and track info.
   Return true if successful or false if an error.
 */
 bool read_toc_aspi (_img_private_t *env);
 
-/*!
-  Run a SCSI MMC command. 
- 
-  env	        private CD structure 
+/**
+  Run a SCSI MMC command.
+
+  env	        private CD structure
   i_timeout     time in milliseconds we will wait for the command
-                to complete. If this value is -1, use the default 
+                to complete. If this value is -1, use the default
 		time-out value.
   p_buf	        Buffer for data, both sending and receiving
   i_buf	        Size of buffer
   e_direction	direction the transfer is to go.
-  cdb	        CDB bytes. All values that are needed should be set on 
+  cdb	        CDB bytes. All values that are needed should be set on
                 input. We'll figure out what the right CDB length should be.
 
   Return 0 if command completed successfully.
  */
-int run_mmc_cmd_aspi( void *p_user_data, 
+int run_mmc_cmd_aspi( void *p_user_data,
 		      unsigned int i_timeout,
-		      unsigned int i_cdb, 
+		      unsigned int i_cdb,
 		      const mmc_cdb_t * p_cdb,
-		      cdio_mmc_direction_t e_direction, 
+		      cdio_mmc_direction_t e_direction,
 		      unsigned int i_buf, /*in/out*/ void *p_buf );
-

--- a/lib/driver/MSWindows/win32.c
+++ b/lib/driver/MSWindows/win32.c
@@ -91,7 +91,7 @@ extern const char* is_cdrom_aspi(const char drive_letter);
 # undef lseek
 #endif
 
-/*!
+/**
   Set the volume of an audio CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -108,7 +108,7 @@ audio_get_volume_win32 ( void *p_user_data,
   }
 }
 
-/*!
+/**
   Pause playing CD through analog output
 
   @param p_cdio the CD object to be acted upon.
@@ -123,7 +123,7 @@ audio_pause_win32 (void *p_user_data)
   }
 }
 
-/*!
+/**
   Playing CD through analog output at the given MSF.
 
   @param p_cdio the CD object to be acted upon.
@@ -138,7 +138,7 @@ audio_play_msf_win32 (void *p_user_data, msf_t *p_start_msf, msf_t *p_end_msf)
   }
 }
 
-/*!
+/**
   Read Audio Subchannel information
 
   @param p_cdio the CD object to be acted upon.
@@ -155,7 +155,7 @@ audio_read_subchannel_win32 (void *p_user_data,
   }
 }
 
-  /*!
+  /**
     Resume playing an audio CD.
 
     @param p_cdio the CD object to be acted upon.
@@ -171,7 +171,7 @@ audio_resume_win32 (void *p_user_data)
   }
 }
 
-/*!
+/**
   Set the volume of an audio CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -277,7 +277,7 @@ is_cdrom_win32(const char drive_letter) {
   }
 }
 
-/*!
+/**
   Run a SCSI MMC command.
 
   env	        private CD structure
@@ -309,7 +309,7 @@ run_mmc_cmd_win32( void *p_user_data, unsigned int i_timeout_ms,
   }
 }
 
-/*!
+/**
   Initialize CD device.
  */
 static bool
@@ -358,7 +358,7 @@ init_win32 (void *p_user_data)
   return b_ret;
 }
 
-/*!
+/**
   Release and free resources associated with cd.
  */
 static void
@@ -379,7 +379,7 @@ free_win32 (void *p_user_data)
   free (p_env);
 }
 
-/*!
+/**
    Reads an audio device into data starting from lsn.
    Returns 0 if no error.
  */
@@ -400,7 +400,7 @@ read_audio_sectors (void *p_user_data, void *p_buf, lsn_t i_lsn,
   }
 }
 
-/*!
+/**
    Reads an audio device into data starting from lsn.
    Returns 0 if no error.
  */
@@ -418,7 +418,7 @@ read_data_sectors_win32 (void *p_user_data, void *p_buf, lsn_t i_lsn,
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
    Reads a single mode1 sector from cd device into data starting from
    lsn. Returns 0 if no error.
  */
@@ -449,7 +449,7 @@ read_mode1_sector_win32 (void *p_user_data, void *p_buf, lsn_t lsn,
   }
 }
 
-/*!
+/**
    Reads nblocks of mode1 sectors from cd device into data starting
    from lsn.
    Returns 0 if no error.
@@ -480,7 +480,7 @@ read_mode1_sectors_win32 (void *p_user_data, void *p_buf, lsn_t lsn,
   return 0;
 }
 
-/*!
+/**
    Reads a single mode2 sector from cd device into data starting
    from lsn. Returns 0 if no error.
  */
@@ -519,7 +519,7 @@ read_mode2_sector_win32 (void *p_user_data, void *data, lsn_t lsn,
   }
 }
 
-/*!
+/**
    Reads nblocks of mode2 sectors from cd device into data starting
    from lsn.
    Returns 0 if no error.
@@ -541,7 +541,7 @@ read_mode2_sectors_win32 (void *p_user_data, void *data, lsn_t lsn,
   return 0;
 }
 
-/*!
+/**
    Return the size of the CD in logical block address (LBA) units.
  */
 static lsn_t
@@ -552,7 +552,7 @@ get_disc_last_lsn_win32 (void *p_user_data)
   return p_env->tocent[p_env->gen.i_tracks].start_lsn;
 }
 
-/*!
+/**
   Set the key "arg" to "value" in source device.
 */
 static int
@@ -586,7 +586,7 @@ set_arg_win32 (void *p_user_data, const char key[], const char value[])
   return 0;
 }
 
-/*!
+/**
   Read and cache the CD's Track Table of Contents and track info.
   Return true if successful or false if an error.
 */
@@ -604,7 +604,7 @@ read_toc_win32 (void *p_user_data)
   return ret;
 }
 
-/*!
+/**
   Close media tray.
  */
 static driver_return_code_t
@@ -637,7 +637,7 @@ open_close_media_win32 (const char *psz_win32_drive, DWORD command_flags)
 #endif
 }
 
-/*!
+/**
   Eject media.
  */
 static driver_return_code_t
@@ -678,7 +678,7 @@ is_mmc_supported(void *user_data)
     return false;
 }
 
-/*!
+/**
   Return the value associated with the key "arg".
 */
 static const char *
@@ -739,7 +739,7 @@ get_cdtext_win32 (void *p_user_data)
   }
 }
 
-/*!
+/**
   Return the media catalog number MCN.
 
   Note: string is malloc'd so caller should free() then returned
@@ -757,7 +757,7 @@ _cdio_get_mcn (const void *p_user_data) {
   }
 }
 
-/*!
+/**
   Return the international standard recording code ISRC.
 
   Note: string is malloc'd so caller should free() then returned
@@ -775,7 +775,7 @@ _cdio_get_track_isrc (const void *p_user_data, track_t i_track) {
   }
 }
 
-/*!
+/**
   Get format of track.
 */
 static track_format_t
@@ -799,7 +799,7 @@ _cdio_get_track_format(void *p_obj, track_t i_track)
   }
 }
 
-/*!
+/**
   Return true if we have XA data (green, mode2 form1) or
   XA data (green, mode2 form2). That is track begins:
   sync - header - subheader
@@ -832,7 +832,7 @@ _cdio_get_track_green(void *p_obj, track_t i_track)
   return ((p_env->tocent[i_track-p_env->gen.i_first_track].Control & 2) != 0);
 }
 
-/*!
+/**
   Return the starting MSF (minutes/secs/frames) for track number
   i_tracks in obj.  Track numbers start at 1.
   The "leadout" track is specified either by
@@ -864,7 +864,7 @@ _cdio_get_track_msf(void *p_user_data, track_t i_tracks, msf_t *p_msf)
 
 #endif /* HAVE_WIN32_CDROM */
 
-/*!
+/**
   Return an array of strings giving possible CD devices.
  */
 char **
@@ -906,7 +906,7 @@ cdio_get_devices_win32 (void)
 #endif /*HAVE_WIN32_CDROM*/
 }
 
-/*!
+/**
   Return a string containing the default CD device if none is specified.
   if CdIo is NULL (we haven't initialized a specific device driver),
   then find a suitable one and return the default device for that.
@@ -931,7 +931,7 @@ cdio_get_default_device_win32(void)
 }
 
 #ifdef HAVE_WIN32_CDROM
-/*!
+/**
   Return the underlying device HANDLE.
  */
 static int
@@ -943,7 +943,7 @@ get_device_fd_win32(void *p_user_data) {
 }
 #endif
 
-/*!
+/**
   Return true if source_name could be a device containing a CD-ROM and
   we are on a MS Windows platform.
 */
@@ -991,7 +991,7 @@ close_tray_win32 (const char *psz_win32_drive)
 #endif /* HAVE_WIN32_CDROM*/
 }
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.
@@ -1010,7 +1010,7 @@ cdio_open_win32 (const char *psz_source_name)
 #endif /* HAVE_WIN32_CDROM */
 }
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.

--- a/lib/driver/MSWindows/win32.h
+++ b/lib/driver/MSWindows/win32.h
@@ -55,14 +55,14 @@ typedef struct {
 
 } _img_private_t;
 
-/*!
+/**
   Pause playing CD through analog output
 
   @param p_cdio the CD object to be acted upon.
 */
 driver_return_code_t audio_pause_win32ioctl (void *p_user_data);
 
-/*!
+/**
   Playing starting at given MSF through analog output
 
   @param p_cdio the CD object to be acted upon.
@@ -70,7 +70,7 @@ driver_return_code_t audio_pause_win32ioctl (void *p_user_data);
 driver_return_code_t audio_play_msf_win32ioctl (void *p_user_data,
 						msf_t *p_start_msf,
 						msf_t *p_end_msf);
-/*!
+/**
   Resume playing an audio CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -78,12 +78,12 @@ driver_return_code_t audio_play_msf_win32ioctl (void *p_user_data,
 */
 driver_return_code_t audio_resume_win32ioctl (void *p_user_data);
 
-/*!
+/**
   Get disc type associated with cd object.
 */
 discmode_t get_discmode_win32ioctl (_img_private_t *p_env);
 
-/*!
+/**
   Get the volume settings of an audio CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -93,7 +93,7 @@ driver_return_code_t
 audio_get_volume_win32ioctl ( void *p_user_data,
 			      /*out*/ cdio_audio_volume_t *p_volume);
 
-/*!
+/**
   Read Audio Subchannel information
 
   @param p_cdio the CD object to be acted upon.
@@ -103,7 +103,7 @@ driver_return_code_t
 audio_read_subchannel_win32ioctl (void *p_user_data,
 				  cdio_subchannel_t *p_subchannel);
 
-/*!
+/**
   Set the volume of an audio CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -112,7 +112,7 @@ audio_read_subchannel_win32ioctl (void *p_user_data,
 driver_return_code_t
 audio_stop_win32ioctl ( void *p_user_data );
 
-/*!
+/**
   Set the volume of an audio CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -122,7 +122,7 @@ driver_return_code_t
 audio_set_volume_win32ioctl ( void *p_user_data,
 			      cdio_audio_volume_t *p_volume);
 
-/*!
+/**
   Close the tray of a CD-ROM
 
   @param p_user_data the CD object to be acted upon.
@@ -130,20 +130,20 @@ audio_set_volume_win32ioctl ( void *p_user_data,
 */
 driver_return_code_t close_tray_win32ioctl (const char *psz_win32_drive);
 
-/*!
+/**
    Reads an audio device using the DeviceIoControl method into data
    starting from lsn.  Returns 0 if no error.
 */
 driver_return_code_t read_audio_sectors_win32ioctl (_img_private_t *p_obj,
 				  void *p_data, lsn_t lsn, unsigned int nblocks);
-/*!
+/**
    Reads a single mode2 sector using the DeviceIoControl method into
    data starting from lsn. Returns 0 if no error.
  */
 int read_mode2_sector_win32ioctl (_img_private_t *p_env, void *p_data,
 				  lsn_t lsn, bool b_form2);
 
-/*!
+/**
    Reads a single mode1 sector using the DeviceIoControl method into
    data starting from lsn. Returns 0 if no error.
  */
@@ -152,7 +152,7 @@ int read_mode1_sector_win32ioctl (_img_private_t *p_env, void *p_data,
 
 const char *is_cdrom_win32ioctl (const char drive_letter);
 
-/*!
+/**
   Run a SCSI MMC command.
 
   env	        private CD structure
@@ -174,18 +174,18 @@ int run_mmc_cmd_win32ioctl( void *p_user_data,
 			    cdio_mmc_direction_t e_direction,
 			    unsigned int i_buf, /*in/out*/ void *p_buf );
 
-/*!
+/**
   Initialize internal structures for CD device.
  */
 bool init_win32ioctl (_img_private_t *p_env);
 
-/*!
+/**
   Read and cache the CD's Track Table of Contents and track info.
   Return true if successful or false if an error.
 */
 bool read_toc_win32ioctl (_img_private_t *p_env);
 
-/*!
+/**
   Get the LSN of the first track of the last session of
   on the CD.
  */
@@ -193,17 +193,17 @@ driver_return_code_t
 get_last_session_win32ioctl (void *p_user_data,
                              /*out*/ lsn_t *i_last_session);
 
-/*!
+/**
   Read CD-Text binary data.
  */
 uint8_t *read_cdtext_win32ioctl (void *p_user_data);
 
-/*!
+/**
   Read CD-Text and return cdtext_t structure.
  */
 cdtext_t *get_cdtext_win32ioctl (void *p_user_data);
 
-/*!
+/**
   Return the media catalog number MCN.
 
   Note: string is malloc'd so caller should free() then returned
@@ -212,7 +212,7 @@ cdtext_t *get_cdtext_win32ioctl (void *p_user_data);
  */
 char *get_mcn_win32ioctl (const _img_private_t *p_env);
 
-/*!
+/**
   Return the international standard recording code ISRC.
 
   Note: string is malloc'd so caller should free() then returned
@@ -222,7 +222,7 @@ char *get_mcn_win32ioctl (const _img_private_t *p_env);
 char *get_track_isrc_win32ioctl (const _img_private_t *p_env,
 				 track_t i_track);
 
-/*!
+/**
   Return the the kind of drive capabilities of device.
 
   Note: string is malloc'd so caller should free() then returned
@@ -234,7 +234,7 @@ void get_drive_cap_aspi (const _img_private_t *p_env,
 			 cdio_drive_write_cap_t *p_write_cap,
 			 cdio_drive_misc_cap_t  *p_misc_cap);
 
-/*!
+/**
   Return the the kind of drive capabilities of device.
 
   Note: string is malloc'd so caller should free() then returned
@@ -246,7 +246,7 @@ void get_drive_cap_win32ioctl (const _img_private_t *p_env,
 			       cdio_drive_write_cap_t *p_write_cap,
 			       cdio_drive_misc_cap_t  *p_misc_cap);
 
-/*!
+/**
   Get the format (XA, DATA, AUDIO) of a track.
 */
 track_format_t get_track_format_win32ioctl(const _img_private_t *p_env,

--- a/lib/driver/MSWindows/win32_ioctl.c
+++ b/lib/driver/MSWindows/win32_ioctl.c
@@ -148,7 +148,7 @@ typedef struct _SCSI_PASS_THROUGH_WITH_BUFFERS {
 
 #define OP_TIMEOUT_MS 60
 
-/*!
+/**
   Pause playing CD through analog output
 
   @param p_cdio the CD object to be acted upon.
@@ -170,7 +170,7 @@ audio_pause_win32ioctl (void *p_user_data)
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
   Playing starting at given MSF through analog output
 
   @param p_cdio the CD object to be acted upon.
@@ -204,7 +204,7 @@ audio_play_msf_win32ioctl (void *p_user_data, msf_t *p_start_msf,
 
 }
 
-/*!
+/**
   Read Audio Subchannel information
 
   @param p_cdio the CD object to be acted upon.

--- a/lib/driver/_cdio_generic.c
+++ b/lib/driver/_cdio_generic.c
@@ -65,7 +65,7 @@
 #define CDIO_LSEEK lseek
 #endif
 
-/*!
+/**
   Eject media -- there's nothing to do here. We always return -2.
   Should we also free resources?
  */
@@ -75,7 +75,7 @@ cdio_generic_unimplemented_eject_media (void *p_user_data) {
   return DRIVER_OP_UNSUPPORTED;
 }
 
-/*!
+/**
   Set the blocksize for subsequent reads.
 */
 driver_return_code_t
@@ -85,7 +85,7 @@ cdio_generic_unimplemented_set_blocksize (void *p_user_data,
   return DRIVER_OP_UNSUPPORTED;
 }
 
-/*!
+/**
   Set the drive speed.
 */
 driver_return_code_t
@@ -95,7 +95,7 @@ cdio_generic_unimplemented_set_speed (void *p_user_data, int i_speed) {
 }
 
 
-/*!
+/**
   Release and free resources associated with cd.
  */
 void
@@ -120,7 +120,7 @@ cdio_generic_free (void *p_user_data)
   free (p_env);
 }
 
-/*!
+/**
   Initialize CD device.
  */
 bool
@@ -149,7 +149,7 @@ cdio_generic_init (void *user_data, int open_flags)
   return true;
 }
 
-/*!
+/**
    Reads a single form1 sector from cd device into data starting
    from lsn.
  */
@@ -161,7 +161,7 @@ cdio_generic_read_form1_sector (void * user_data, void *data, lsn_t lsn)
   return cdio_generic_read(user_data, data, CDIO_CD_FRAMESIZE);
 }
 
-/*!
+/**
   Reads into buf the next size bytes.
   Returns -1 on error.
   Is in fact libc's lseek()/lseek64().
@@ -173,7 +173,7 @@ cdio_generic_lseek (void *user_data, off_t offset, int whence)
   return CDIO_LSEEK(p_env->fd, offset, whence);
 }
 
-/*!
+/**
   Reads into buf the next size bytes.
   Returns -1 on error.
   Is in fact libc's read().
@@ -185,7 +185,7 @@ cdio_generic_read (void *user_data, void *buf, size_t size)
   return read(p_env->fd, buf, size);
 }
 
-/*!
+/**
   Release and free resources associated with stream or disk image.
 */
 void
@@ -202,7 +202,7 @@ cdio_generic_stdio_free (void *p_user_data)
 }
 
 
-/*!
+/**
   Return true if source_name could be a device containing a CD-ROM.
 */
 bool
@@ -217,7 +217,7 @@ cdio_is_device_generic(const char *source_name)
   return (S_ISBLK(buf.st_mode) || S_ISCHR(buf.st_mode));
 }
 
-/*!
+/**
   Like above, but don't give a warning device doesn't exist.
 */
 bool
@@ -230,7 +230,7 @@ cdio_is_device_quiet_generic(const char *source_name)
   return (S_ISBLK(buf.st_mode) || S_ISCHR(buf.st_mode));
 }
 
-/*!
+/**
   Add/allocate a drive to the end of drives.
   Use cdio_free_device_list() to free this device_list.
 */
@@ -311,7 +311,7 @@ get_cdtext_generic (void *p_user_data)
   return p_env->cdtext;
 }
 
-/*!
+/**
   Get disc type associated with cd object.
 */
 discmode_t
@@ -346,7 +346,7 @@ get_discmode_generic (void *p_user_data )
   return get_discmode_cd_generic(p_user_data);
 }
 
-/*!
+/**
   Get disc type associated with cd object.
 */
 discmode_t
@@ -420,7 +420,7 @@ get_discmode_cd_generic (void *p_user_data )
   return discmode;
 }
 
-/*!
+/**
   Return the number of of the first track.
   CDIO_INVALID_TRACK is returned on error.
 */
@@ -436,7 +436,7 @@ get_first_track_num_generic(void *p_user_data)
 }
 
 
-/*!
+/**
   Return the number of tracks in the current medium.
 */
 track_t
@@ -451,7 +451,7 @@ get_num_tracks_generic(void *p_user_data)
 }
 
 
-/*!
+/**
   Read CD-Text information for a CdIo_t object .
 
   return pointer to raw cdtext on success,
@@ -465,7 +465,7 @@ read_cdtext_generic(void *p_env)
   return mmc_read_cdtext ( p_user_data->cdio );
 }
 
-/*! Return number of channels in track: 2 or 4; -2 if not
+/** Return number of channels in track: 2 or 4; -2 if not
   implemented or -1 for error.
   Not meaningful if track is not an audio track.
 */
@@ -476,7 +476,7 @@ get_track_channels_generic(const void *p_user_data, track_t i_track)
   return p_env->track_flags[i_track].channels;
 }
 
-/*! Return 1 if copy is permitted on the track, 0 if not, or -1 for error.
+/** Return 1 if copy is permitted on the track, 0 if not, or -1 for error.
   Is this meaningful if not an audio track?
 */
 track_flag_t
@@ -486,7 +486,7 @@ get_track_copy_permit_generic(void *p_user_data, track_t i_track)
   return p_env->track_flags[i_track].copy_permit;
 }
 
-/*! Return 1 if track has pre-emphasis, 0 if not, or -1 for error.
+/** Return 1 if track has pre-emphasis, 0 if not, or -1 for error.
   Is this meaningful if not an audio track?
 
   pre-emphasis is a non linear frequency response.
@@ -498,7 +498,7 @@ get_track_preemphasis_generic(const void *p_user_data, track_t i_track)
   return p_env->track_flags[i_track].preemphasis;
 }
 
-/*!
+/**
   Return the underlying device file descriptor.
  */
 int

--- a/lib/driver/_cdio_stdio.c
+++ b/lib/driver/_cdio_stdio.c
@@ -142,7 +142,7 @@ _stdio_free(void *user_data)
   free(ud);
 }
 
-/*!
+/**
   Like fseek/fseeko(3) and in fact may be the same.
 
   This  function sets the file position indicator for the stream
@@ -187,7 +187,7 @@ _stdio_stat(void *p_user_data)
   return ud->st_size;
 }
 
-/*!
+/**
   Like fread(3) and in fact is about the same.
 
   DESCRIPTION:
@@ -238,7 +238,7 @@ _stdio_read(void *user_data, void *buf, size_t count)
   return read_count;
 }
 
-/*!
+/**
   Deallocate resources associated with obj. After this obj is unusable.
 */
 void

--- a/lib/driver/_cdio_stdio.h
+++ b/lib/driver/_cdio_stdio.h
@@ -22,7 +22,7 @@
 
 #include "_cdio_stream.h"
 
-/*!
+/**
   Initialize a new stdio stream reading from pathname.
   A pointer to the stream is returned or NULL if there was an error.
 
@@ -31,7 +31,7 @@
  */
 CdioDataSource_t * cdio_stdio_new(const char psz_path[]);
 
-/*!
+/**
   Deallocate resources assocaited with obj. After this obj is unusable.
 */
 void cdio_stdio_destroy(CdioDataSource_t *p_obj);
@@ -40,7 +40,7 @@ void cdio_stdio_destroy(CdioDataSource_t *p_obj);
 #endif /* CDIO_STDIO_H_ */
 
 
-/* 
+/*
  * Local variables:
  *  c-file-style: "gnu"
  *  tab-width: 8

--- a/lib/driver/aix.c
+++ b/lib/driver/aix.c
@@ -147,7 +147,7 @@ str_to_access_mode_aix(const char *psz_access_mode)
 }
 
 
-/*!
+/**
   Initialize CD device.
  */
 static bool
@@ -179,7 +179,7 @@ init_aix (_img_private_t *p_env)
   return true;
 }
 
-/*!
+/**
   Run a SCSI MMC command.
 
   p_user_data   internal CD structure.
@@ -228,7 +228,7 @@ run_mmc_cmd_aix( void *p_user_data, unsigned int i_timeout_ms,
   return i_rc;
 }
 
-/*!
+/**
    Reads audio sectors from CD device into data starting from lsn.
    Returns 0 if no error.
 
@@ -282,7 +282,7 @@ _read_audio_sectors_aix (void *p_user_data, void *data, lsn_t lsn,
   return 0;
 }
 
-/*!
+/**
    Reads a single mode1 sector from cd device into data starting
    from lsn. Returns 0 if no error.
  */
@@ -298,7 +298,7 @@ _read_mode1_sector_aix (void *env, void *data, lsn_t lsn,
 #endif
 }
 
-/*!
+/**
    Reads nblocks of mode2 sectors from cd device into data starting
    from lsn.
    Returns 0 if no error.
@@ -321,7 +321,7 @@ _read_mode1_sectors_aix (void *p_user_data, void *p_data, lsn_t lsn,
   return 0;
 }
 
-/*!
+/**
    Reads a single mode2 sector from cd device into data starting from lsn.
    Returns 0 if no error.
  */
@@ -382,7 +382,7 @@ _read_mode2_sector_aix (void *p_user_data, void *p_data, lsn_t lsn,
   return 0;
 }
 
-/*!
+/**
    Reads nblocks of mode2 sectors from cd device into data starting
    from lsn.
    Returns 0 if no error.
@@ -406,7 +406,7 @@ _read_mode2_sectors_aix (void *p_user_data, void *data, lsn_t lsn,
 }
 
 
-/*!
+/**
    Return the size of the CD in logical block address (LBA) units.
  */
 static lsn_t
@@ -432,7 +432,7 @@ get_disc_last_lsn_aix (void *p_user_data)
   return i_size;
 }
 
-/*!
+/**
   Set the arg "key" with "value" in the source device.
   Currently "source" and "access-mode" are valid keys.
   "source" sets the source device in I/O operations
@@ -496,7 +496,7 @@ aixioc_send(_img_private_t *p_env, int cmd, void *arg, bool b_print_err)
   return true;
 }
 
-/*!
+/**
   Read and cache the CD's Track Table of Contents and track info.
   via a SCSI MMC READ_TOC (FULTOC).  Return true if successful or
   false if an error.
@@ -542,7 +542,7 @@ read_toc_ioctl_aix (void *p_user_data)
   return true;
 }
 
-/*!
+/**
   Read and cache the CD's Track Table of Contents and track info.
   via a SCSI MMC READ_TOC (FULTOC).  Return true if successful or
   false if an error.
@@ -637,7 +637,7 @@ read_toc_aix (void *p_user_data)
   return false;
 }
 
-/*!
+/**
   Eject media in CD drive. If successful, as a side effect we
   also free obj.
  */
@@ -684,7 +684,7 @@ is_mmc_supported(void *user_data)
     return (_AM_NONE == env->access_mode) ? false : true;
 }
 
-/*!
+/**
   Return the value associated with the key "arg".
 */
 static const char *
@@ -707,7 +707,7 @@ get_arg_aix (void *p_user_data, const char key[])
   return NULL;
 }
 
-/*!
+/**
   Return a string containing the default CD device if none is specified.
  */
 char *
@@ -716,7 +716,7 @@ cdio_get_default_device_aix(void)
   return strdup(DEFAULT_CDIO_DEVICE);
 }
 
-/*!
+/**
   Get disc type associated with cd object.
 */
 
@@ -750,7 +750,7 @@ get_discmode_aix (void *p_user_data)
   }
 }
 
-/*!
+/**
   Get format of track.
 */
 static track_format_t
@@ -787,7 +787,7 @@ get_track_format_aix(void *p_user_data, track_t i_track)
 
 }
 
-/*!
+/**
   Return true if we have XA data (green, mode2 form1) or
   XA data (green, mode2 form2). That is track begins:
   sync - header - subheader
@@ -821,7 +821,7 @@ _cdio_get_track_green(void *p_user_data, track_t i_track)
 #endif
 }
 
-/*!
+/**
   Return the starting MSF (minutes/secs/frames) for track number
   track_num in obj.  Track numbers usually start at something
   greater than 0, usually 1.
@@ -860,7 +860,7 @@ _cdio_get_track_msf(void *p_user_data, track_t i_track, msf_t *msf)
 }
 
 #else
-/*!
+/**
   Return a string containing the default VCD device if none is specified.
  */
 char *
@@ -871,7 +871,7 @@ cdio_get_default_device_aix(void)
 
 #endif /* HAVE_AIX_CDROM */
 
-/*!
+/**
   Return an array of strings giving possible CD devices.
  */
 char **
@@ -916,7 +916,7 @@ cdio_get_devices_aix (void)
 #endif /*HAVE_AIX_CDROM*/
 }
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.
@@ -927,7 +927,7 @@ cdio_open_aix (const char *psz_source_name)
   return cdio_open_am_aix(psz_source_name, NULL);
 }
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.

--- a/lib/driver/audio.c
+++ b/lib/driver/audio.c
@@ -14,7 +14,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/*! Audio (via line output) related routines. */
+/** Audio (via line output) related routines. */
 
 
 #ifdef HAVE_CONFIG_H
@@ -29,23 +29,23 @@
 
 /* Return the number of seconds (discarding frame portion) of an MSF */
 uint32_t
-cdio_audio_get_msf_seconds(msf_t *p_msf) 
+cdio_audio_get_msf_seconds(msf_t *p_msf)
 {
-  return 
+  return
     cdio_from_bcd8(p_msf->m)*CDIO_CD_SECS_PER_MIN + cdio_from_bcd8(p_msf->s);
 }
 
-/*!
+/**
   Get volume of an audio CD.
-  
+
   @param p_cdio the CD object to be acted upon.
-  
+
 */
-driver_return_code_t 
+driver_return_code_t
 cdio_audio_get_volume (CdIo_t *p_cdio,  /*out*/ cdio_audio_volume_t *p_volume)
 {
   cdio_audio_volume_t temp_audio_volume;
-  
+
   if (!p_cdio) return DRIVER_OP_UNINIT;
 
   if (!p_volume) p_volume = &temp_audio_volume;
@@ -55,13 +55,13 @@ cdio_audio_get_volume (CdIo_t *p_cdio,  /*out*/ cdio_audio_volume_t *p_volume)
     return DRIVER_OP_UNSUPPORTED;
   }
 }
-/*!
+/**
   Playing CD through analog output
-  
+
   @param p_cdio the CD object to be acted upon.
 */
-driver_return_code_t 
-cdio_audio_pause (CdIo_t *p_cdio) 
+driver_return_code_t
+cdio_audio_pause (CdIo_t *p_cdio)
 {
   if (!p_cdio) return DRIVER_OP_UNINIT;
 
@@ -72,12 +72,12 @@ cdio_audio_pause (CdIo_t *p_cdio)
   }
 }
 
-/*!
+/**
   Playing CD through analog output at the given MSF.
-  
+
   @param p_cdio the CD object to be acted upon.
 */
-driver_return_code_t 
+driver_return_code_t
 cdio_audio_play_msf (CdIo_t *p_cdio, msf_t *p_start_msf, msf_t *p_end_msf)
 {
   if (!p_cdio) return DRIVER_OP_UNINIT;
@@ -89,12 +89,12 @@ cdio_audio_play_msf (CdIo_t *p_cdio, msf_t *p_start_msf, msf_t *p_end_msf)
   }
 }
 
-/*!
+/**
   Playing CD through analog output
-  
+
   @param p_cdio the CD object to be acted upon.
 */
-driver_return_code_t 
+driver_return_code_t
 cdio_audio_play_track_index (CdIo_t *p_cdio, cdio_track_index_t *p_track_index)
 {
   if (!p_cdio) return DRIVER_OP_UNINIT;
@@ -106,12 +106,12 @@ cdio_audio_play_track_index (CdIo_t *p_cdio, cdio_track_index_t *p_track_index)
   }
 }
 
-/*!
+/**
   Get subchannel information.
-  
+
   @param p_cdio the CD object to be acted upon.
 */
-driver_return_code_t 
+driver_return_code_t
 cdio_audio_read_subchannel (CdIo_t *p_cdio, cdio_subchannel_t *p_subchannel)
 {
   if (!p_cdio) return DRIVER_OP_UNINIT;
@@ -123,13 +123,13 @@ cdio_audio_read_subchannel (CdIo_t *p_cdio, cdio_subchannel_t *p_subchannel)
   }
 }
 
-/*!
+/**
   Resume playing an audio CD.
-  
+
   @param p_cdio the CD object to be acted upon.
-  
+
 */
-driver_return_code_t 
+driver_return_code_t
 cdio_audio_resume (CdIo_t *p_cdio)
 {
   if (!p_cdio) return DRIVER_OP_UNINIT;
@@ -141,13 +141,13 @@ cdio_audio_resume (CdIo_t *p_cdio)
   }
 }
 
-/*!
+/**
   Set volume of an audio CD.
-  
+
   @param p_cdio the CD object to be acted upon.
-  
+
 */
-driver_return_code_t 
+driver_return_code_t
 cdio_audio_set_volume (CdIo_t *p_cdio, cdio_audio_volume_t *p_volume)
 {
   if (!p_cdio) return DRIVER_OP_UNINIT;
@@ -159,13 +159,13 @@ cdio_audio_set_volume (CdIo_t *p_cdio, cdio_audio_volume_t *p_volume)
   }
 }
 
-/*!
+/**
   Resume playing an audio CD.
-  
+
   @param p_cdio the CD object to be acted upon.
-  
+
 */
-driver_return_code_t 
+driver_return_code_t
 cdio_audio_stop (CdIo_t *p_cdio)
 {
   if (!p_cdio) return DRIVER_OP_UNINIT;
@@ -178,7 +178,7 @@ cdio_audio_stop (CdIo_t *p_cdio)
 }
 
 
-/* 
+/*
  * Local variables:
  *  c-file-style: "gnu"
  *  tab-width: 8

--- a/lib/driver/cdio.c
+++ b/lib/driver/cdio.c
@@ -38,7 +38,7 @@
 #include <cdio/util.h>
 #include "cdio_private.h"
 
-/*!
+/**
   Return the value associatied with key. NULL is returned if obj is NULL
   or "key" does not exist.
  */
@@ -70,7 +70,7 @@ cdio_new (generic_img_private_t *p_env, cdio_funcs_t *p_funcs)
   return p_new_cdio;
 }
 
-/*!
+/**
   Set the arg "key" with "value" in the source device.
 */
 driver_return_code_t

--- a/lib/driver/cdio_private.h
+++ b/lib/driver/cdio_private.h
@@ -59,14 +59,14 @@ static inline char *libcdio_strndup(const char *s, size_t n)
 }
 #endif /*HAVE_STRNDUP*/
 
-  /*!
+  /**
     Get directory name from file name.
 
     Callers must free return value after use.
    */
   extern char *cdio_dirname(const char *fname);
 
-  /*!
+  /**
     Construct an absolute file name from path and file name.
 
     Callers must free return value after use.
@@ -90,7 +90,7 @@ extern "C" {
 
   typedef struct {
 
-    /*!
+    /**
       Get volume of an audio CD.
 
       @param p_env the CD object to be acted upon.
@@ -99,14 +99,14 @@ extern "C" {
     driver_return_code_t (*audio_get_volume)
          (void *p_env,  /*out*/ cdio_audio_volume_t *p_volume);
 
-    /*!
+    /**
       Pause playing CD through analog output
 
       @param p_env the CD object to be acted upon.
     */
     driver_return_code_t (*audio_pause) (void *p_env);
 
-    /*!
+    /**
       Playing CD through analog output
 
       @param p_env the CD object to be acted upon.
@@ -115,7 +115,7 @@ extern "C" {
                                              msf_t *p_start_msf,
                                              msf_t *p_end_msf );
 
-    /*!
+    /**
       Playing CD through analog output
 
       @param p_env the CD object to be acted upon.
@@ -123,7 +123,7 @@ extern "C" {
     driver_return_code_t (*audio_play_track_index)
          ( void *p_env, cdio_track_index_t *p_track_index );
 
-    /*!
+    /**
       Get subchannel information.
 
       @param p_env the CD object to be acted upon.
@@ -131,7 +131,7 @@ extern "C" {
     driver_return_code_t (*audio_read_subchannel)
          ( void *p_env, cdio_subchannel_t *subchannel );
 
-    /*!
+    /**
       Resume playing an audio CD.
 
       @param p_env the CD object to be acted upon.
@@ -139,7 +139,7 @@ extern "C" {
     */
     driver_return_code_t (*audio_resume) ( void *p_env );
 
-    /*!
+    /**
       Set volume of an audio CD.
 
       @param p_env the CD object to be acted upon.
@@ -148,7 +148,7 @@ extern "C" {
     driver_return_code_t (*audio_set_volume)
          ( void *p_env,  cdio_audio_volume_t *p_volume );
 
-    /*!
+    /**
       Stop playing an audio CD.
 
       @param p_env the CD object to be acted upon.
@@ -156,7 +156,7 @@ extern "C" {
     */
     driver_return_code_t (*audio_stop) ( void *p_env );
 
-    /*!
+    /**
       Eject media in CD drive. If successful, as a side effect we
       also free p_env.
 
@@ -165,23 +165,23 @@ extern "C" {
     */
     driver_return_code_t (*eject_media) ( void *p_env );
 
-    /*!
+    /**
       Release and free resources associated with cd.
     */
     void (*free) (void *p_env);
 
-    /*!
+    /**
       Return the value associated with the key "arg".
     */
     const char * (*get_arg) (void *p_env, const char key[]);
 
-    /*!
+    /**
       Get the block size for subsequent read requests, via a SCSI MMC
       MODE_SENSE 6 command.
     */
     int (*get_blocksize) ( void *p_env );
 
-    /*!
+    /**
       Get cdtext information for a CdIo object.
 
       @param obj the CD object that may contain CD-TEXT information.
@@ -190,7 +190,7 @@ extern "C" {
     */
     cdtext_t * (*get_cdtext) ( void *p_env );
 
-    /*!
+    /**
       Get raw cdtext information as on the disc for a CdIo object
 
       @param obj the CD object that may contain CD-TEXT information.
@@ -201,7 +201,7 @@ extern "C" {
     */
     uint8_t * (*get_cdtext_raw) ( void *p_env );
 
-    /*!
+    /**
       Return the underlying device file descriptor.
 
       @param obj the CD object.
@@ -210,7 +210,7 @@ extern "C" {
     */
     int (*get_device_fd) ( void *p_env );
 
-    /*!
+    /**
       Return an array of device names. if CdIo is NULL (we haven't
       initialized a specific device driver), then find a suitable device
       driver.
@@ -219,7 +219,7 @@ extern "C" {
     */
     char ** (*get_devices) ( void );
 
-    /*!
+    /**
       Get the default CD device.
 
       @return a string containing the default CD device or NULL is
@@ -231,18 +231,18 @@ extern "C" {
     */
     char * (*get_default_device) ( void );
 
-    /*!
+    /**
       Return the size of the CD in logical block address (LBA) units.
       @return the lsn. On error 0 or CDIO_INVALD_LSN.
     */
     lsn_t (*get_disc_last_lsn) ( void *p_env );
 
-    /*!
+    /**
       Get disc mode associated with cd_obj.
     */
     discmode_t (*get_discmode) ( void *p_env );
 
-    /*!
+    /**
       Return the what kind of device we've got.
 
       See cd_types.h for a list of bitmasks for the drive type;
@@ -251,20 +251,20 @@ extern "C" {
                            cdio_drive_read_cap_t  *p_read_cap,
                            cdio_drive_write_cap_t *p_write_cap,
                            cdio_drive_misc_cap_t  *p_misc_cap);
-    /*!
+    /**
       Return the number of of the first track.
       CDIO_INVALID_TRACK is returned on error.
     */
     track_t (*get_first_track_num) ( void *p_env );
 
-    /*!
+    /**
       Get the CD-ROM hardware info via a SCSI MMC INQUIRY command.
       False is returned if we had an error getting the information.
     */
     bool (*get_hwinfo)
          ( const CdIo_t *p_cdio, /* out*/ cdio_hwinfo_t *p_hw_info );
 
-    /*! Get the LSN of the first track of the last session of
+    /** Get the LSN of the first track of the last session of
       on the CD.
 
        @param p_cdio the CD object to be acted upon.
@@ -273,7 +273,7 @@ extern "C" {
     driver_return_code_t (*get_last_session)
          ( void *p_env, /*out*/ lsn_t *i_last_session );
 
-    /*!
+    /**
       Find out if media has changed since the last call.
       @param p_env the CD object to be acted upon.
       @return 1 if media has changed since last call, 0 if not. Error
@@ -281,31 +281,31 @@ extern "C" {
     */
     int (*get_media_changed) ( const void *p_env );
 
-    /*!
+    /**
       Return the media catalog number MCN from the CD or NULL if
       there is none or we don't have the ability to get it.
     */
     char * (*get_mcn) ( const void *p_env );
 
-    /*!
+    /**
       Return the number of tracks in the current medium.
       CDIO_INVALID_TRACK is returned on error.
     */
     track_t (*get_num_tracks) ( void *p_env );
 
-    /*! Return number of channels in track: 2 or 4; -2 if not
+    /** Return number of channels in track: 2 or 4; -2 if not
       implemented or -1 for error.
       Not meaningful if track is not an audio track.
     */
     int (*get_track_channels) ( const void *p_env, track_t i_track );
 
-    /*! Return 0 if track is copy protected, 1 if not, or -1 for error
+    /** Return 0 if track is copy protected, 1 if not, or -1 for error
       or -2 if not implemented (yet). Is this meaningful if not an
       audio track?
     */
     track_flag_t (*get_track_copy_permit) ( void *p_env, track_t i_track );
 
-    /*!
+    /**
       Return the starting LBA for track number
       i_track in p_env.  Tracks numbers start at 1.
       The "leadout" track is specified either by
@@ -314,14 +314,14 @@ extern "C" {
     */
     lba_t (*get_track_lba) ( void *p_env, track_t i_track );
 
-    /*!
+    /**
       Return the starting LBA for the pregap for track number
       i_track in p_env.  Tracks numbers start at 1.
       CDIO_INVALID_LBA is returned on error.
     */
     lba_t (*get_track_pregap_lba) ( const void *p_env, track_t i_track );
 
-    /*!
+    /**
       Return the International Standard Recording Code (ISRC) for track number
       i_track in p_cdio.  Track numbers start at 1.
 
@@ -330,12 +330,12 @@ extern "C" {
     */
     char * (*get_track_isrc) ( const void *p_env, track_t i_track );
 
-    /*!
+    /**
       Get format of track.
     */
     track_format_t (*get_track_format) ( void *p_env, track_t i_track );
 
-    /*!
+    /**
       Return true if we have XA data (green, mode2 form1) or
       XA data (green, mode2 form2). That is track begins:
       sync - header - subheader
@@ -345,7 +345,7 @@ extern "C" {
     */
     bool (*get_track_green) ( void *p_env, track_t i_track );
 
-    /*!
+    /**
       Return the starting MSF (minutes/secs/frames) for track number
       i_track in p_env.  Tracks numbers start at 1.
       The "leadout" track is specified either by
@@ -354,35 +354,35 @@ extern "C" {
     */
     bool (*get_track_msf) ( void *p_env, track_t i_track, msf_t *p_msf );
 
-    /*! Return 1 if track has pre-emphasis, 0 if not, or -1 for error
+    /** Return 1 if track has pre-emphasis, 0 if not, or -1 for error
       or -2 if not implemented (yet). Is this meaningful if not an
       audio track?
     */
     track_flag_t (*get_track_preemphasis)
          ( const void  *p_env, track_t i_track );
 
-    /*!
+    /**
       lseek - reposition read/write file offset
       Returns (off_t) -1 on error.
       Similar to libc's lseek()
     */
     off_t (*lseek) ( void *p_env, off_t offset, int whence );
 
-    /*!
+    /**
       Reads into buf the next size bytes.
       Returns -1 on error.
       Similar to libc's read()
     */
     ssize_t (*read) ( void *p_env, void *p_buf, size_t i_size );
 
-    /*!
+    /**
       Reads a single mode2 sector from cd device into buf starting
       from lsn. Returns 0 if no error.
     */
     int (*read_audio_sectors) ( void *p_env, void *p_buf, lsn_t i_lsn,
                                 unsigned int i_blocks );
 
-    /*!
+    /**
       Read a data sector
 
       @param p_env environment to read from
@@ -403,14 +403,14 @@ extern "C" {
          ( void *p_env, void *p_buf, lsn_t i_lsn, uint16_t i_blocksize,
            uint32_t i_blocks );
 
-    /*!
+    /**
       Reads a single mode2 sector from cd device into buf starting
       from lsn. Returns 0 if no error.
     */
     int (*read_mode2_sector)
          ( void *p_env, void *p_buf, lsn_t i_lsn, bool b_mode2_form2 );
 
-    /*!
+    /**
       Reads i_blocks of mode2 sectors from cd device into data starting
       from lsn.
       Returns 0 if no error.
@@ -419,14 +419,14 @@ extern "C" {
          ( void *p_env, void *p_buf, lsn_t i_lsn, bool b_mode2_form2,
            unsigned int i_blocks );
 
-    /*!
+    /**
       Reads a single mode1 sector from cd device into buf starting
       from lsn. Returns 0 if no error.
     */
     int (*read_mode1_sector)
          ( void *p_env, void *p_buf, lsn_t i_lsn, bool mode1_form2 );
 
-    /*!
+    /**
       Reads i_blocks of mode1 sectors from cd device into data starting
       from lsn.
       Returns 0 if no error.
@@ -437,7 +437,7 @@ extern "C" {
 
     bool (*read_toc) ( void *p_env ) ;
 
-    /*!
+    /**
       Run a SCSI MMC command.
 
       cdio              CD structure set by cdio_open().
@@ -455,18 +455,18 @@ extern "C" {
     */
     mmc_run_cmd_fn_t run_mmc_cmd;
 
-    /*!
+    /**
       Set the arg "key" with "value" in the source device.
     */
     int (*set_arg) ( void *p_env, const char key[], const char value[] );
 
-    /*!
+    /**
       Set the blocksize for subsequent reads.
     */
     driver_return_code_t (*set_blocksize) ( void *p_env,
                                             uint16_t i_blocksize );
 
-    /*!
+    /**
       Set the drive speed.
 
       @return 0 if everything went okay, -1 if we had an error. is -2
@@ -486,7 +486,7 @@ extern "C" {
 
 #define CDIO_HEADER_FLAGS_DISABLE_RR_DD 0x0001
 
-  /*! Implementation of CdIo type */
+  /** Implementation of CdIo type */
   struct _CdIo {
     cdio_header_t header;    /**< Internal header - MUST come first. */
     driver_id_t   driver_id; /**< Particular driver opened. */
@@ -538,7 +538,7 @@ extern "C" {
      on a particular host. */
   extern CdIo_driver_t CdIo_all_drivers[];
 
-  /*!
+  /**
     Add/allocate a drive to the end of drives.
     Use cdio_free_device_list() to free this device_list.
   */
@@ -557,7 +557,7 @@ extern "C" {
   CdIo_t * cdio_open_netbsd (const char *psz_source);
   char * cdio_get_default_device_netbsd(void);
   char **cdio_get_devices_netbsd(void);
-  /*! Set up CD-ROM for reading using the NetBSD driver. The device_name is
+  /** Set up CD-ROM for reading using the NetBSD driver. The device_name is
       the some sort of device name.
 
      NULL is returned on error or there is no FreeBSD driver.
@@ -567,45 +567,45 @@ extern "C" {
   CdIo_t * cdio_open_am_netbsd (const char *psz_source,
                                 const char *psz_access_mode);
 
-  /*! DEPRECATED: use cdio_have_driver().
+  /** DEPRECATED: use cdio_have_driver().
     True if AIX driver is available. */
   bool cdio_have_aix    (void);
 
-  /*! DEPRECATED: use cdio_have_driver().
+  /** DEPRECATED: use cdio_have_driver().
     True if BSDI driver is available. */
   bool cdio_have_bsdi    (void);
 
-  /*! DEPRECATED: use cdio_have_driver().
+  /** DEPRECATED: use cdio_have_driver().
     True if FreeBSD driver is available. */
   bool cdio_have_freebsd (void);
 
-  /*! DEPRECATED: use cdio_have_driver().
+  /** DEPRECATED: use cdio_have_driver().
     True if GNU/Linux driver is available. */
   bool cdio_have_linux   (void);
 
-  /*! DEPRECATED: use cdio_have_driver().
+  /** DEPRECATED: use cdio_have_driver().
     True if Sun Solaris driver is available. */
   bool cdio_have_solaris (void);
 
-  /*! DEPRECATED: use cdio_have_driver().
+  /** DEPRECATED: use cdio_have_driver().
     True if IBM OS2 driver is available. */
   bool cdio_have_os2     (void);
 
-  /*! DEPRECATED: use cdio_have_driver().
+  /** DEPRECATED: use cdio_have_driver().
     True if Apple OSX driver is available. */
   bool cdio_have_osx     (void);
 
-  /*! DEPRECATED: use cdio_have_driver().
+  /** DEPRECATED: use cdio_have_driver().
     True if Microsoft Windows driver is available. */
   bool cdio_have_win32   (void);
 
-  /*! True if Nero driver is available. */
+  /** True if Nero driver is available. */
   bool cdio_have_nrg     (void);
 
-  /*! True if BIN/CUE driver is available. */
+  /** True if BIN/CUE driver is available. */
   bool cdio_have_bincue  (void);
 
-  /*! True if cdrdao CDRDAO driver is available. */
+  /** True if cdrdao CDRDAO driver is available. */
   bool cdio_have_cdrdao  (void);
 
 #ifdef __cplusplus

--- a/lib/driver/cdtext.c
+++ b/lib/driver/cdtext.c
@@ -196,7 +196,7 @@ const char *cdtext_language[MAX_CDTEXT_LANGUAGE_CODE + 1] =
   "Amharic"
 };
 
-/*!
+/**
   Return string representation of given field type.
 */
 const char *
@@ -208,7 +208,7 @@ cdtext_field2str(cdtext_field_t i)
     return cdtext_field[i];
 }
 
-/*!
+/**
   Return string representation of the given genre code.
 */
 const char *
@@ -220,7 +220,7 @@ cdtext_genre2str(cdtext_genre_t i)
     return cdtext_genre[i];
 }
 
-/*!
+/**
   Return string representation of the given language code.
 */
 const char *
@@ -233,7 +233,7 @@ cdtext_lang2str(cdtext_lang_t i)
   return "INVALID";
 }
 
-/*!
+/**
   Free memory associated with the given cdtext_t object.
 
   @param p_cdtext the CD-TEXT object
@@ -259,7 +259,7 @@ cdtext_destroy(cdtext_t *p_cdtext)
   free(p_cdtext);
 }
 
-/*!
+/**
   Returns a copy of the return value of cdtext_get_const or NULL.
 
   Must be freed using cdio_free() when done.
@@ -275,7 +275,7 @@ cdtext_get(const cdtext_t *p_cdtext, cdtext_field_t field, track_t track)
     return strdup(ret);
 }
 
-/*!
+/**
   Returns value of the given field.
 
   NULL is returned if key is CDTEXT_INVALID or the field is not set.
@@ -296,7 +296,7 @@ cdtext_get_const(const cdtext_t *p_cdtext, cdtext_field_t field, track_t track)
   return p_cdtext->block[p_cdtext->block_i].track[track].field[field];
 }
 
-/*!
+/**
   Returns the discs genre code.
 
   @param p_cdtext the CD-TEXT object
@@ -309,7 +309,7 @@ cdtext_get_genre(const cdtext_t *p_cdtext)
   return p_cdtext->block[p_cdtext->block_i].genre_code;
 }
 
-/*!
+/**
   Returns the currently active language.
 
   @param p_cdtext the CD-TEXT object
@@ -322,7 +322,7 @@ cdtext_get_language(const cdtext_t *p_cdtext)
   return p_cdtext->block[p_cdtext->block_i].language_code;
 }
 
-/*!
+/**
   Returns the first track number.
 
   @param p_cdtext the CD-TEXT object
@@ -335,7 +335,7 @@ cdtext_get_first_track(const cdtext_t *p_cdtext)
   return p_cdtext->block[p_cdtext->block_i].first_track;
 }
 
-/*!
+/**
   Returns the last track number.
 
   @param p_cdtext the CD-TEXT object
@@ -348,7 +348,7 @@ cdtext_get_last_track(const cdtext_t *p_cdtext)
   return p_cdtext->block[p_cdtext->block_i].last_track;
 }
 
-/*!
+/**
   @deprecated Use cdtext_list_languages_v2()
 
   Returns a list of available languages or NULL.
@@ -386,7 +386,7 @@ cdtext_lang_t
   return avail;
 }
 
-/*!
+/**
   Returns an array of available languages or NULL.
   The index of an array element may be used to select the corresponding
   language block by call cdtext_set_language_index().
@@ -421,7 +421,7 @@ cdtext_lang_t
   return p_cdtext->languages;
 }
 
-/*!
+/**
   Select the given language by block index. See cdtext_list_languages_v2().
   If the index is bad, or no language block with that index was read:
   select the default language at index 0 and return false.
@@ -445,7 +445,7 @@ cdtext_set_language_index(cdtext_t *p_cdtext, int idx)
   return true;
 }
 
-/*!
+/**
   Try to select the given language.
   Select default language if specified is not available or invalid and
   return false.
@@ -475,7 +475,7 @@ cdtext_select_language(cdtext_t *p_cdtext, cdtext_lang_t language)
   return false;
 }
 
-/*!
+/**
   Initialize a new cdtext structure.
 
   When the structure is no longer needed, release the
@@ -509,7 +509,7 @@ cdtext_t
   return p_cdtext;
 }
 
-/*!
+/**
   Returns associated cdtext_field_t if field is a CD-TEXT keyword.
 
   Internal function.
@@ -530,7 +530,7 @@ cdtext_is_field (const char *key)
   return CDTEXT_FIELD_INVALID;
 }
 
-/*!
+/**
   Return the language code of a given language string representation.
   This is the inverse of cdtext_lang2str().
 
@@ -555,7 +555,7 @@ cdtext_str2lang (const char *lang)
   return CDTEXT_LANGUAGE_INVALID;
 }
 
-/*!
+/**
   Sets the given field at the given track to the given value.
 
   Recodes to UTF-8 if charset is not NULL.
@@ -590,7 +590,7 @@ cdtext_set(cdtext_t *p_cdtext, cdtext_field_t key, const uint8_t *value,
 
 #define CDTEXT_COMPARE_CHAR(buf, c, db) ((buf)[0] == c && (! db || (buf)[1] == c) )
 
-/*!
+/**
   Read a binary CD-TEXT and fill a cdtext struct.
 
   @param p_cdtext the CD-TEXT object
@@ -876,7 +876,7 @@ cdtext_data_init(cdtext_t *p_cdtext, uint8_t *wdata, size_t i_data)
 }
 
 
-/*!
+/**
   Fills cdtext_pack_t with information read from p_data
 
   @param p_pack out

--- a/lib/driver/cdtext_private.h
+++ b/lib/driver/cdtext_private.h
@@ -107,12 +107,12 @@ struct cdtext_blocksize_s
 typedef struct cdtext_pack_s cdtext_pack_t;
 typedef struct cdtext_blocksize_s cdtext_blocksize_t;
 
-/*! Structure for CD-TEXT of a track. */
+/** Structure for CD-TEXT of a track. */
 struct cdtext_track_s {
   char *field[MAX_CDTEXT_FIELDS];
 };
 
-/*! Structure for CD-TEXT of a block. */
+/** Structure for CD-TEXT of a block. */
 struct cdtext_block_s {
   struct cdtext_track_s track[CDTEXT_NUM_TRACKS_MAX]; /**< 0: disc; 1..99: tracks */
   cdtext_genre_t genre_code;                          /**< genre code of the disc */
@@ -122,7 +122,7 @@ struct cdtext_block_s {
   track_t        last_track;                          /**< last track number      */
 };
 
-/*! Structure for CD-TEXT of a disc.
+/** Structure for CD-TEXT of a disc.
 
   @see cdtext_init, cdtext_destroy, cdtext_get, and cdtext_set.
  */
@@ -134,7 +134,7 @@ struct cdtext_s {
 
 int cdtext_read_pack (cdtext_pack_t *pack, const uint8_t *data);
 
-/*!
+/**
   returns enum of field if key is a CD-Text keyword,
   returns CDTEXT_FIELD_INVALID otherwise.
 */

--- a/lib/driver/device.c
+++ b/lib/driver/device.c
@@ -15,7 +15,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/*! device- and driver-related routines. */
+/** device- and driver-related routines. */
 
 
 #ifdef HAVE_CONFIG_H
@@ -326,7 +326,7 @@ cdio_driver_describe(driver_id_t driver_id)
   return CdIo_all_drivers[driver_id].describe;
 }
 
-/*!
+/**
   Initialize CD Reading and control routines. Should be called first.
   May be implicitly called by other routines if not called first.
 */
@@ -354,7 +354,7 @@ cdio_init(void)
   return true;
 }
 
-/*!
+/**
   Free any resources associated with cdio.
 */
 void
@@ -369,7 +369,7 @@ cdio_destroy (CdIo_t *p_cdio)
   free (p_cdio);
 }
 
-/*!
+/**
   Close media tray in CD drive if there is a routine to do so.
 
   @param psz_drive the name of CD-ROM to be closed. If NULL, we will
@@ -423,7 +423,7 @@ cdio_close_tray (const char *psz_orig_drive, /*in/out*/ driver_id_t
   return DRIVER_OP_UNSUPPORTED;
 }
 
-/*!
+/**
   Eject media in CD drive if there is a routine to do so.
 
   @param p_cdio the CD object to be acted upon.
@@ -448,7 +448,7 @@ cdio_eject_media (CdIo_t **pp_cdio)
   }
 }
 
-/*!
+/**
   Eject media in CD drive if there is a routine to do so. If you want
   to scan for any CD-ROM and eject that, pass NULL for psz_drive.
 
@@ -473,7 +473,7 @@ cdio_eject_media_drive (const char *psz_drive)
   }
 }
 
-/*!
+/**
   Free device list returned by cdio_get_devices or
   cdio_get_devices_with_cap.
 */
@@ -490,7 +490,7 @@ cdio_free_device_list (char * ppsz_device_list[])
 }
 
 
-/*!
+/**
   Return a string containing the default CD device if none is specified.
   if p_cdio is NULL (we haven't initialized a specific device driver),
   then find a suitable one and return the default device for that.
@@ -519,7 +519,7 @@ cdio_get_default_device (const CdIo_t *p_cdio)
   }
 }
 
-/*!
+/**
   Return a string containing the default CD device if none is specified.
   if p_driver_id is DRIVER_UNKNOWN or DRIVER_DEVICE
   then find a suitable one set the default device for that.
@@ -564,7 +564,7 @@ cdio_get_device_fd (CdIo_t *p_cdio)
   }
 }
 
-/*!Return an array of device names. If you want a specific
+/**Return an array of device names. If you want a specific
   devices, dor a driver give that device, if you want hardware
   devices, give DRIVER_DEVICE and if you want all possible devices,
   image drivers and hardware drivers give DRIVER_UNKNOWN.
@@ -608,7 +608,7 @@ cdio_get_devices_ret (/*in/out*/ driver_id_t *p_driver_id)
   }
 }
 
-/*!
+/**
   Return an array of device names in search_devices that have at
   least the capabilities listed by cap.  If search_devices is NULL,
   then we'll search all possible CD drives.
@@ -706,7 +706,7 @@ cdio_get_devices_with_cap_ret (/*in*/ char* search_devices[],
   return ppsz_drives_ret;
 }
 
-/*!
+/**
   Return the the kind of drive capabilities of device.
 
   Note: string is malloc'd so caller should free() then returned
@@ -729,7 +729,7 @@ cdio_get_drive_cap (const CdIo_t *p_cdio,
   }
 }
 
-/*!
+/**
   Return the the kind of drive capabilities of device.
 
   Note: string is malloc'd so caller should free() then returned
@@ -755,7 +755,7 @@ cdio_get_drive_cap_dev (const char *device,
 }
 
 
-/*!
+/**
   Return a string containing the name of the driver in use.
   if CdIo is NULL (we haven't initialized a specific device driver),
   then return NULL.
@@ -767,7 +767,7 @@ cdio_get_driver_name (const CdIo_t *p_cdio)
   return cdio_get_driver_name_from_id(p_cdio->driver_id);
 }
 
-/*!
+/**
   Return a string containing the name of the driver in use from the driver_id.
   if CdIo is NULL (we haven't initialized a specific device driver),
   then return NULL.
@@ -778,7 +778,7 @@ cdio_get_driver_name_from_id (driver_id_t driver_id)
   return CdIo_all_drivers[driver_id].name;
 }
 
-/*!
+/**
   Return the driver id.
   if CdIo is NULL (we haven't initialized a specific device driver),
   then return DRIVER_UNKNOWN.
@@ -790,7 +790,7 @@ cdio_get_driver_id (const CdIo_t *p_cdio)
   return p_cdio->driver_id;
 }
 
-/*!
+/**
   Return a string containing the name of the driver in use.
   if CdIo is NULL (we haven't initialized a specific device driver),
   then return NULL.
@@ -808,7 +808,7 @@ cdio_get_hwinfo (const CdIo_t *p_cdio, cdio_hwinfo_t *hw_info)
   }
 }
 
-/*!
+/**
   Return the session number of the last on the CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -823,7 +823,7 @@ driver_return_code_t cdio_get_last_session (CdIo_t *p_cdio,
   return DRIVER_OP_UNSUPPORTED;
 }
 
-/*!
+/**
   Find out if media has changed since the last call.
   @param p_cdio the CD object to be acted upon.
   @return 1 if media has changed since last call, 0 if not. Error
@@ -937,7 +937,7 @@ cdio_is_device(const char *psz_source, driver_id_t driver_id)
 }
 
 
-/*! Sets up to read from place specified by source_name and
+/** Sets up to read from place specified by source_name and
   driver_id. This should be called before using any other routine,
   except cdio_init. This will call cdio_init, if that hasn't been
   done previously.
@@ -950,7 +950,7 @@ cdio_open (const char *orig_source_name, driver_id_t driver_id)
   return cdio_open_am(orig_source_name, driver_id, NULL);
 }
 
-/*! Sets up to read from place specified by source_name and
+/** Sets up to read from place specified by source_name and
   driver_id. This should be called before using any other routine,
   except cdio_init. This will call cdio_init, if that hasn't been
   done previously.
@@ -1011,7 +1011,7 @@ cdio_open_am (const char *psz_orig_source, driver_id_t driver_id,
 }
 
 
-/*!
+/**
   Set up CD-ROM for reading. The device_name is
   the some sort of device name.
 
@@ -1024,7 +1024,7 @@ cdio_open_cd (const char *psz_source)
   return cdio_open_am_cd(psz_source, NULL);
 }
 
-/*!
+/**
   Set up CD-ROM for reading. The device_name is
   the some sort of device name.
 
@@ -1048,7 +1048,7 @@ cdio_open_am_cd (const char *psz_source, const char *psz_access_mode)
   return scan_for_driver(cdio_device_drivers, psz_source, psz_access_mode);
 }
 
-/*!
+/**
   Set the blocksize for subsequent reads.
 */
 driver_return_code_t
@@ -1059,7 +1059,7 @@ cdio_set_blocksize ( const CdIo_t *p_cdio, int i_blocksize )
   return p_cdio->op.set_blocksize(p_cdio->env, i_blocksize);
 }
 
-/*!
+/**
   Set the drive speed.
 
   @param p_cdio          CD structure set by cdio_open().

--- a/lib/driver/disc.c
+++ b/lib/driver/disc.c
@@ -25,37 +25,37 @@
 
 #ifdef HAVE_STDBOOL_H
 # include <stdbool.h>
-#endif 
+#endif
 
 #include <cdio/cdio.h>
 #include "cdio_private.h"
 
 /* Must match discmode enumeration */
 const char *discmode2str[] = {
-  "CD-DA", 
-  "CD-DATA (Mode 1)", 
-  "CD DATA (Mode 2)", 
+  "CD-DA",
+  "CD-DATA (Mode 1)",
+  "CD DATA (Mode 2)",
   "CD-ROM Mixed",
-  "DVD-ROM", 
-  "DVD-RAM", 
-  "DVD-R", 
-  "DVD-RW", 
+  "DVD-ROM",
+  "DVD-RAM",
+  "DVD-R",
+  "DVD-RW",
   "HD DVD ROM",
-  "HD_DVD RAM", 
-  "HD DVD-R", 
+  "HD_DVD RAM",
+  "HD DVD-R",
   "DVD+R",
-  "DVD+RW", 
-  "DVD+RW DL", 
-  "DVD+R DL", 
-  "Unknown/unclassified DVD", 
+  "DVD+RW",
+  "DVD+RW DL",
+  "DVD+R DL",
+  "Unknown/unclassified DVD",
   "No information",
   "Error in getting information",
-  "CD-i" 
+  "CD-i"
 };
 
-/*! 
+/**
   Get cdtext information for a CdIo object .
-  
+
   @param obj the CD object that may contain CD-TEXT information.
   @return the CD-TEXT object or NULL if obj is NULL
   or CD-TEXT information does not exist.
@@ -64,7 +64,7 @@ cdtext_t *
 cdio_get_cdtext (CdIo *obj)
 {
   if (obj == NULL) return NULL;
-  
+
   if (NULL != obj->op.get_cdtext) {
     return obj->op.get_cdtext (obj->env);
   } else {
@@ -72,9 +72,9 @@ cdio_get_cdtext (CdIo *obj)
   }
 }
 
-/*! 
+/**
   Get binary cdtext information for a CdIo object .
-  
+
   @param obj the CD object that may contain CD-TEXT information.
   @return pointer to allocated memory area holding the raw CD-TEXT
   or NULL if obj is NULL or CD-TEXT does not exist. Return value
@@ -92,27 +92,27 @@ cdio_get_cdtext_raw (CdIo *obj)
   }
 }
 
-/*!
+/**
   Get the size of the CD in logical block address (LBA) units.
-  
+
   @param p_cdio the CD object queried
   @return the lsn. On error 0 or CDIO_INVALD_LSN.
 */
-lsn_t 
+lsn_t
 cdio_get_disc_last_lsn(const CdIo_t *p_cdio)
 {
   if (!p_cdio) return CDIO_INVALID_LSN;
   return p_cdio->op.get_disc_last_lsn (p_cdio->env);
 }
 
-/*! 
+/**
   Get medium associated with cd_obj.
 */
 discmode_t
 cdio_get_discmode (CdIo_t *cd_obj)
 {
   if (!cd_obj) return CDIO_DISC_MODE_ERROR;
-  
+
   if (cd_obj->op.get_discmode) {
     return cd_obj->op.get_discmode (cd_obj->env);
   } else {
@@ -120,13 +120,13 @@ cdio_get_discmode (CdIo_t *cd_obj)
   }
 }
 
-/*!
+/**
   Return a string containing the name of the driver in use.
-  if CdIo is NULL (we haven't initialized a specific device driver), 
+  if CdIo is NULL (we haven't initialized a specific device driver),
   then return NULL.
 */
 char *
-cdio_get_mcn (const CdIo_t *p_cdio) 
+cdio_get_mcn (const CdIo_t *p_cdio)
 {
   if (p_cdio && p_cdio->op.get_mcn) {
     return p_cdio->op.get_mcn (p_cdio->env);
@@ -136,7 +136,7 @@ cdio_get_mcn (const CdIo_t *p_cdio)
 }
 
 bool
-cdio_is_discmode_cdrom(discmode_t discmode) 
+cdio_is_discmode_cdrom(discmode_t discmode)
 {
   switch (discmode) {
   case CDIO_DISC_MODE_CD_DA:
@@ -151,7 +151,7 @@ cdio_is_discmode_cdrom(discmode_t discmode)
 }
 
 bool
-cdio_is_discmode_dvd(discmode_t discmode) 
+cdio_is_discmode_dvd(discmode_t discmode)
 {
   switch (discmode) {
     case CDIO_DISC_MODE_DVD_ROM:

--- a/lib/driver/generic.h
+++ b/lib/driver/generic.h
@@ -38,7 +38,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-  /*!
+  /**
     Things common to private device structures. Even though not all
     devices may have some of these fields, by listing common ones
     we facilitate writing generic routines and even cut-and-paste
@@ -89,13 +89,13 @@ extern "C" {
     char *scsi_tuple;
   } generic_img_private_t;
 
-  /*!
+  /**
     Bogus eject media when there is no ejectable media, e.g. a disk image
     We always return 2. Should we also free resources?
   */
   driver_return_code_t cdio_generic_unimplemented_eject_media (void *p_env);
 
-  /*!
+  /**
     Set the blocksize for subsequent reads.
 
     @return -2 since it's not implemented.
@@ -104,7 +104,7 @@ extern "C" {
   cdio_generic_unimplemented_set_blocksize (void *p_user_data,
                                             uint16_t i_blocksize);
 
-  /*!
+  /**
     Set the drive speed.
 
     @return -2 since it's not implemented.
@@ -112,68 +112,68 @@ extern "C" {
   driver_return_code_t cdio_generic_unimplemented_set_speed (void *p_user_data,
                                                              int i_speed);
 
-  /*!
+  /**
     Release and free resources associated with cd.
   */
   void cdio_generic_free (void *p_env);
 
-  /*!
+  /**
     Initialize CD device.
   */
   bool cdio_generic_init (void *p_env, int open_mode);
 
-  /*!
+  /**
     Reads into buf the next size bytes.
     Returns -1 on error.
     Is in fact libc's read().
   */
   off_t cdio_generic_lseek (void *p_env, off_t offset, int whence);
 
-  /*!
+  /**
     Reads into buf the next size bytes.
     Returns -1 on error.
     Is in fact libc's read().
   */
   ssize_t cdio_generic_read (void *p_env, void *p_buf, size_t size);
 
-  /*!
+  /**
     Reads a single form1 sector from cd device into data starting
     from lsn. Returns 0 if no error.
   */
   int cdio_generic_read_form1_sector (void * user_data, void *data,
                                       lsn_t lsn);
 
-  /*!
+  /**
     Release and free resources associated with stream or disk image.
   */
   void cdio_generic_stdio_free (void *env);
 
-  /*!
+  /**
     Return true if source_name could be a device containing a CD-ROM on
     Win32
   */
   bool cdio_is_device_win32(const char *source_name);
 
-  /*!
+  /**
     Return true if source_name could be a device containing a CD-ROM on
     OS/2
   */
   bool cdio_is_device_os2(const char *source_name);
 
 
-  /*!
+  /**
     Return true if source_name could be a device containing a CD-ROM on
     most Unix servers with block and character devices.
   */
   bool cdio_is_device_generic(const char *source_name);
 
 
-  /*!
+  /**
     Like above, but don't give a warning device doesn't exist.
   */
   bool cdio_is_device_quiet_generic(const char *source_name);
 
-  /*!
+  /**
     Get cdtext information for a CdIo object .
 
     @param obj the CD object that may contain CD-TEXT information.
@@ -182,40 +182,40 @@ extern "C" {
   */
   cdtext_t *get_cdtext_generic (void *p_user_data);
 
-  /*!
+  /**
     Return the number of of the first track.
     CDIO_INVALID_TRACK is returned on error.
   */
   track_t get_first_track_num_generic(void *p_user_data);
 
-  /*!
+  /**
     Return the number of tracks in the current medium.
   */
   track_t get_num_tracks_generic(void *p_user_data);
 
-  /*!
+  /**
     Get disc type associated with cd object.
   */
   discmode_t get_discmode_generic (void *p_user_data );
 
-  /*!
+  /**
     Same as above but only handles CD cases
   */
   discmode_t get_discmode_cd_generic (void *p_user_data );
 
-  /*! Return number of channels in track: 2 or 4; -2 if not
+  /** Return number of channels in track: 2 or 4; -2 if not
     implemented or -1 for error.
     Not meaningful if track is not an audio track.
   */
   int  get_track_channels_generic(const void *p_user_data, track_t i_track);
 
-  /*! Return 1 if copy is permitted on the track, 0 if not, or -1 for error.
+  /** Return 1 if copy is permitted on the track, 0 if not, or -1 for error.
     Is this meaningful if not an audio track?
   */
   track_flag_t get_track_copy_permit_generic(void *p_user_data,
                                              track_t i_track);
 
-  /*! Return 1 if track has pre-emphasis, 0 if not, or -1 for error.
+  /** Return 1 if track has pre-emphasis, 0 if not, or -1 for error.
     Is this meaningful if not an audio track?
 
     pre-emphasis is a non linear frequency response.
@@ -223,13 +223,13 @@ extern "C" {
   track_flag_t get_track_preemphasis_generic(const void *p_user_data,
                                              track_t i_track);
 
-  /*!
+  /**
     Return the underlying device file descriptor.
    */
   int
   get_device_fd_generic(void *p_user_data);
 
-  /*!
+  /**
     Read cdtext information for a CdIo object .
 
     return true on success, false on error or CD-Text information does
@@ -239,7 +239,7 @@ extern "C" {
 
   void set_track_flags(track_flags_t *p_track_flag, uint8_t flag);
 
-  /*! Read mode 1 or mode2 sectors (using cooked mode).  */
+  /** Read mode 1 or mode2 sectors (using cooked mode).  */
   driver_return_code_t read_data_sectors_generic (void *p_user_data,
                                                   void *p_buf, lsn_t i_lsn,
                                                   uint16_t i_blocksize,

--- a/lib/driver/gnu_linux.c
+++ b/lib/driver/gnu_linux.c
@@ -226,7 +226,7 @@ check_mounts_linux(const char *mtab)
   return NULL;
 }
 
-/*!
+/**
   Get the volume of an audio CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -240,7 +240,7 @@ audio_get_volume_linux (void *p_user_data,
   return ioctl(p_env->gen.fd, CDROMVOLREAD, p_volume);
 }
 
-/*!
+/**
   Pause playing CD through analog output
 
   @param p_cdio the CD object to be acted upon.
@@ -253,7 +253,7 @@ audio_pause_linux (void *p_user_data)
   return ioctl(p_env->gen.fd, CDROMPAUSE);
 }
 
-/*!
+/**
   Playing starting at given MSF through analog output
 
   @param p_cdio the CD object to be acted upon.
@@ -276,7 +276,7 @@ audio_play_msf_linux (void *p_user_data, msf_t *p_start_msf, msf_t *p_end_msf)
   return ioctl(p_env->gen.fd, CDROMPLAYMSF, &cdrom_msf);
 }
 
-/*!
+/**
   Playing CD through analog output at the desired track and index
 
   @param p_cdio the CD object to be acted upon.
@@ -291,7 +291,7 @@ audio_play_track_index_linux (void *p_user_data,
   return ioctl(p_env->gen.fd, CDROMPLAYTRKIND, p_track_index);
 }
 
-/*!
+/**
   Read Audio Subchannel information
 
   @param p_user_data the CD object to be acted upon.
@@ -334,7 +334,7 @@ audio_read_subchannel_linux (void *p_user_data,
   }
 }
 
-/*!
+/**
   Resume playing an audio CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -347,7 +347,7 @@ audio_resume_linux (void *p_user_data)
   return ioctl(p_env->gen.fd, CDROMRESUME, 0);
 }
 
-/*!
+/**
   Set the volume of an audio CD.
 
   @param p_user_data the CD object to be acted upon.
@@ -360,7 +360,7 @@ audio_set_volume_linux (void *p_user_data, cdio_audio_volume_t *p_volume)
   return ioctl(p_env->gen.fd, CDROMVOLCTRL, p_volume);
 }
 
-/*!
+/**
   Stop playing an audio CD.
 
   @param p_user_data the CD object to be acted upon.
@@ -373,7 +373,7 @@ audio_stop_linux (void *p_user_data)
   return ioctl(p_env->gen.fd, CDROMSTOP);
 }
 
-/*!
+/**
   Release and free resources associated with cd for linux driver.
  */
 static void
@@ -397,7 +397,7 @@ is_mmc_supported(void *user_data)
     return (_AM_NONE == env->access_mode) ? false : true;
 }
 
-/*!
+/**
   Return the value associated with the key "arg".
 */
 static const char *
@@ -432,7 +432,7 @@ get_arg_linux (void *env, const char key[])
 
 #undef USE_LINUX_CAP
 #ifdef USE_LINUX_CAP
-/*!
+/**
   Return the the kind of drive capabilities of device.
 
   Note: string is malloc'd so caller should free() then returned
@@ -499,7 +499,7 @@ get_drive_cap_linux (const void *p_user_data,
 }
 #endif
 
-/*! Get the LSN of the first track of the last session of
+/** Get the LSN of the first track of the last session of
   on the CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -526,7 +526,7 @@ get_last_session_linux (void *p_user_data,
 
 
 
-/*!
+/**
   Find out if media has changed since the last call.
   @param p_user_data the environment object to be acted upon.
   @return 1 if media has changed since last call, 0 if not. Error
@@ -550,7 +550,7 @@ get_media_changed_linux (const void *p_user_data) {
 #endif
 }
 
-/*!
+/**
   Return the media catalog number MCN.
 
   Note: string is malloc'd so caller should free() then returned
@@ -568,7 +568,7 @@ get_mcn_linux (const void *p_user_data) {
   return strdup((char *)mcn.medium_catalog_number);
 }
 
-/*!
+/**
   Return the international standard recording code ISRC.
 
   Note: string is malloc'd so caller should free() then returned
@@ -582,7 +582,7 @@ get_track_isrc_linux (const void *p_user_data, track_t i_track) {
   return mmc_get_track_isrc( p_env->gen.cdio, i_track );
 }
 
-/*!
+/**
   Get format of track.
 */
 static track_format_t
@@ -615,7 +615,7 @@ get_track_format_linux(void *p_user_data, track_t i_track)
 
 }
 
-/*!
+/**
   Return true if we have XA data (green, mode2 form1) or
   XA data (green, mode2 form2). That is track begins:
   sync - header - subheader
@@ -642,7 +642,7 @@ get_track_green_linux(void *p_user_data, track_t i_track)
   return ((p_env->tocent[i_track].cdte_ctrl & 2) != 0);
 }
 
-/*!
+/**
   Return the starting MSF (minutes/secs/frames) for track number
   track_num in obj.  Track numbers usually start at something
   greater than 0, usually 1.
@@ -679,7 +679,7 @@ get_track_msf_linux(void *p_user_data, track_t i_track, msf_t *msf)
 }
 
 
-/*!
+/**
   Check, if a device is mounted and return the target (=mountpoint)
   needed for umounting (idea taken from libunieject).
  */
@@ -724,7 +724,7 @@ static int is_mounted (const char * device, char * target) {
   return 0;
 }
 
-/*!
+/**
   Umount a filesystem specified by it's mountpoint. We must do this
   by forking and calling the umount command, because the raw umount
   (or umount2) system calls will *always* trigger an EPERM even if
@@ -759,7 +759,7 @@ static int do_umount(char * target) {
 }
 
 
-/*!
+/**
   Eject media in CD-ROM drive. Return DRIVER_OP_SUCCESS if successful,
   DRIVER_OP_ERROR on error.
  */
@@ -836,7 +836,7 @@ eject_media_linux (void *p_user_data) {
   return ret;
 }
 
-/*!
+/**
   Get disc type associated with cd object.
 */
 static discmode_t
@@ -865,7 +865,7 @@ dvd_discmode_linux (_img_private_t *p_env)
   return discmode;
 }
 
-/*!
+/**
   Get disc type associated with the cd object.
 */
 static discmode_t
@@ -1033,7 +1033,7 @@ _read_mode2_sectors (_img_private_t *p_env, void *p_buf, lba_t lba,
   return retval;
 }
 
-/*!
+/**
    Reads a single mode1 sector from cd device into data starting
    from lsn. Returns 0 if no error.
  */
@@ -1044,7 +1044,7 @@ _read_mode1_sector_linux (void *p_user_data, void *p_data, lsn_t lsn,
   return cdio_generic_read_form1_sector(p_user_data, p_data, lsn);
 }
 
-/*!
+/**
    Reads i_blocks of mode2 sectors from cd device into data starting
    from lsn.
    Returns 0 if no error.
@@ -1067,7 +1067,7 @@ _read_mode1_sectors_linux (void *p_user_data, void *p_data, lsn_t lsn,
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
    Reads a single mode2 sector from cd device into data starting
    from lsn. Returns 0 if no error.
  */
@@ -1136,7 +1136,7 @@ _read_mode2_sector_linux (void *p_user_data, void *p_data, lsn_t lsn,
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
    Reads i_blocks of mode2 sectors from cd device into data starting
    from lsn.
    Returns 0 if no error.
@@ -1160,7 +1160,7 @@ _read_mode2_sectors_linux (void *p_user_data, void *data, lsn_t lsn,
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
   Read and cache the CD's Track Table of Contents and track info.
   Return false if successful or true if an error.
 */
@@ -1239,7 +1239,7 @@ read_toc_linux (void *p_user_data)
   return true;
 }
 
-/*!
+/**
   Run a SCSI MMC command.
 
   cdio          CD structure set by cdio_open().
@@ -1328,7 +1328,7 @@ run_mmc_cmd_linux(void *p_user_data,
   }
 }
 
-/*!
+/**
    Return the size of the CD in logical block address (LBA) units.
    @return the lsn. On error return CDIO_INVALID_LSN.
 
@@ -1367,7 +1367,7 @@ get_disc_last_lsn_linux (void *p_user_data)
   return i_size;
 }
 
-/*!
+/**
   Set the arg "key" with "value" in the source device.
   Currently "source" and "access-mode" are valid keys.
   "source" sets the source device in I/O operations
@@ -1429,7 +1429,7 @@ set_speed_linux (void *p_user_data, int i_drive_speed)
 
 #endif /* HAVE_LINUX_CDROM */
 
-/*!
+/**
   Return an array of strings giving possible CD devices.
  */
 char **
@@ -1484,7 +1484,7 @@ cdio_get_devices_linux (void)
 #endif /*HAVE_LINUX_CDROM*/
 }
 
-/*!
+/**
   Return a string containing the default CD device.
  */
 char *
@@ -1533,7 +1533,7 @@ cdio_get_default_device_linux(void)
 #endif /*HAVE_LINUX_CDROM*/
 }
 
-/*!
+/**
   Close tray on CD-ROM.
 
   @param psz_device the CD-ROM drive to be closed.
@@ -1580,7 +1580,7 @@ close_tray_linux (const char *psz_device)
 }
 
 #ifdef HAVE_LINUX_CDROM
-/*!
+/**
   Produce a text composed from the system SCSI address tuple according to
   habits of Linux 2.4 and 2.6 :  "Bus,Host,Channel,Target,Lun" and store
   it in generic_img_private_t.scsi_tuple.
@@ -1652,7 +1652,7 @@ no_tuple:;
 }
 #endif
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.
@@ -1667,7 +1667,7 @@ cdio_open_linux (const char *psz_source_name)
 #endif /*HAVE_LINUX_CDROM*/
 }
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.

--- a/lib/driver/image.h
+++ b/lib/driver/image.h
@@ -16,7 +16,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/*!
+/**
   Header for image drivers. In contrast to image_common.h which contains
   routines, this header like most C headers does not depend on anything
   defined before it is included.
@@ -39,7 +39,7 @@
 #include "cdio_private.h"
 #include <cdio/sector.h>
 
-/*!
+/**
   The universal format for information about a track for CD image readers
   It may be that some fields can be derived from other fields.
   Over time this structure may get cleaned up. Possibly this can be

--- a/lib/driver/image/bincue.c
+++ b/lib/driver/image/bincue.c
@@ -89,7 +89,7 @@ static lsn_t get_disc_last_lsn_bincue(void *p_user_data);
 #include "image_common.h"
 static bool parse_cuefile(_img_private_t *cd, const char *toc_name);
 
-/*!
+/**
   Initialize image structures.
  */
 static bool
@@ -132,7 +132,7 @@ _init_bincue(_img_private_t *p_env)
   return true;
 }
 
-/*!
+/**
   Reads into buf the next size bytes.
   Returns -1 on error.
   Would be libc's seek() but we have to adjust for the extra track header
@@ -186,7 +186,7 @@ _lseek_bincue (void *p_user_data, off_t offset, int whence)
   }
 }
 
-/*!
+/**
   Reads into buf the next size bytes.
   Returns -1 on error.
   FIXME:
@@ -241,7 +241,7 @@ _read_bincue (void *p_user_data, void *data, size_t size)
   return final_size;
 }
 
-/*!
+/**
    Return the size of the CD in logical block address (LBA) units.
  */
 static lsn_t
@@ -924,7 +924,7 @@ parse_cuefile (_img_private_t *cd, const char *psz_cue_name)
 
 }
 
-/*!
+/**
    Reads a single audio sector from CD device into data starting
    from lsn. Returns 0 if no error.
  */
@@ -946,7 +946,7 @@ _read_audio_sectors_bincue (void *p_user_data, void *data, lsn_t lsn,
   return ret == 0;
 }
 
-/*!
+/**
    Reads a single mode2 sector from cd device into data starting
    from lsn. Returns 0 if no error.
  */
@@ -972,7 +972,7 @@ _read_mode1_sector_bincue (void *p_user_data, void *data, lsn_t lsn,
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
    Reads nblocks of mode1 sectors from cd device into data starting
    from lsn.
    Returns 0 if no error.
@@ -995,7 +995,7 @@ _read_mode1_sectors_bincue (void *p_user_data, void *data, lsn_t lsn,
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
    Reads a single mode1 sector from cd device into data starting
    from lsn. Returns 0 if no error.
  */
@@ -1032,7 +1032,7 @@ _read_mode2_sector_bincue (void *p_user_data, void *data, lsn_t lsn,
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
    Reads nblocks of mode2 sectors from cd device into data starting
    from lsn.
    Returns 0 if no error.
@@ -1090,7 +1090,7 @@ static void Win32Glob(const char* pattern, const char* szCurPath, char ***drives
 }
 #endif
 
-/*!
+/**
   Return an array of strings giving possible BIN/CUE disk images.
  */
 char **
@@ -1118,7 +1118,7 @@ cdio_get_devices_bincue (void)
   return drives;
 }
 
-/*!
+/**
   Return a string containing the default CD device.
  */
 char *
@@ -1146,7 +1146,7 @@ get_hwinfo_bincue ( const CdIo_t *p_cdio, /*out*/ cdio_hwinfo_t *hw_info)
 
 }
 
-/*!
+/**
   Return the number of tracks in the current medium.
   CDIO_INVALID_TRACK is returned on error.
 */
@@ -1164,7 +1164,7 @@ _get_track_format_bincue(void *p_user_data, track_t i_track)
   return p_env->tocent[i_track-p_env->gen.i_first_track].track_format;
 }
 
-/*!
+/**
   Return true if we have XA data (green, mode2 form1) or
   XA data (green, mode2 form2). That is track begins:
   sync - header - subheader
@@ -1185,7 +1185,7 @@ _get_track_green_bincue(void *p_user_data, track_t i_track)
   return p_env->tocent[i_track-p_env->gen.i_first_track].track_green;
 }
 
-/*!
+/**
   Return the starting LSN track number
   i_track in obj.  Track numbers start at 1.
   The "leadout" track is specified either by
@@ -1207,7 +1207,7 @@ _get_lba_track_bincue(void *p_user_data, track_t i_track)
     return CDIO_INVALID_LBA;
 }
 
-/*!
+/**
   Return corresponding BIN file if psz_cue_name is a cue file or NULL
   if not a CUE file.
 */
@@ -1248,7 +1248,7 @@ cdio_is_cuefile(const char *psz_cue_name)
   return NULL;
 }
 
-/*!
+/**
   Return corresponding CUE file if psz_bin_name is a bin file or NULL
   if not a BIN file.
 */
@@ -1277,7 +1277,7 @@ cdio_is_binfile(const char *psz_bin_name)
   return NULL;
 }
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.
@@ -1291,7 +1291,7 @@ cdio_open_am_bincue (const char *psz_source_name, const char *psz_access_mode)
   return cdio_open_bincue(psz_source_name);
 }
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.

--- a/lib/driver/image/cdrdao.c
+++ b/lib/driver/image/cdrdao.c
@@ -102,7 +102,7 @@ check_track_is_blocksize_multiple(const char *psz_fname,
 }
 
 
-/*!
+/**
   Initialize image structures.
  */
 static bool
@@ -138,7 +138,7 @@ _init_cdrdao (_img_private_t *env)
   return true;
 }
 
-/*!
+/**
   Reads into buf the next size bytes.
   Returns -1 on error.
   Would be libc's seek() but we have to adjust for the extra track header
@@ -184,7 +184,7 @@ _lseek_cdrdao (void *user_data, off_t offset, int whence)
   }
 }
 
-/*!
+/**
   Reads into buf the next size bytes.
   Returns -1 on error.
   FIXME:
@@ -239,7 +239,7 @@ _read_cdrdao (void *user_data, void *data, size_t size)
   return final_size;
 }
 
-/*!
+/**
    Return the size of the CD in logical block address (LBA) units.
 
    FIXME: this assumes there is only one source for data or
@@ -1016,7 +1016,7 @@ parse_tocfile (_img_private_t *cd, const char *psz_cue_name)
   return false;
 }
 
-/*!
+/**
    Reads a single audio sector from CD device into data starting
    from lsn. Returns 0 if no error.
  */
@@ -1038,7 +1038,7 @@ _read_audio_sectors_cdrdao (void *user_data, void *data, lsn_t lsn,
   return ret == 0;
 }
 
-/*!
+/**
    Reads a single mode2 sector from cd device into data starting
    from lsn. Returns 0 if no error.
  */
@@ -1065,7 +1065,7 @@ _read_mode1_sector_cdrdao (void *user_data, void *data, lsn_t lsn,
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
    Reads nblocks of mode1 sectors from cd device into data starting
    from lsn.
    Returns 0 if no error.
@@ -1088,7 +1088,7 @@ _read_mode1_sectors_cdrdao (void *user_data, void *data, lsn_t lsn,
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
    Reads a single mode1 sector from cd device into data starting
    from lsn. Returns 0 if no error.
  */
@@ -1130,7 +1130,7 @@ _read_mode2_sector_cdrdao (void *user_data, void *data, lsn_t lsn,
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
    Reads nblocks of mode2 sectors from cd device into data starting
    from lsn.
    Returns 0 if no error.
@@ -1152,7 +1152,7 @@ _read_mode2_sectors_cdrdao (void *user_data, void *data, lsn_t lsn,
   return 0;
 }
 
-/*!
+/**
   Return an array of strings giving possible TOC disk images.
  */
 char **
@@ -1176,7 +1176,7 @@ cdio_get_devices_cdrdao (void)
   return drives;
 }
 
-/*!
+/**
   Return a string containing the default CD device.
  */
 char *
@@ -1203,7 +1203,7 @@ get_hwinfo_cdrdao ( const CdIo_t *p_cdio, /*out*/ cdio_hwinfo_t *hw_info)
   return true;
 }
 
-/*!
+/**
   Return the number of tracks in the current medium.
   CDIO_INVALID_TRACK is returned on error.
 */
@@ -1220,7 +1220,7 @@ _get_track_format_cdrdao(void *p_user_data, track_t i_track)
   return p_env->tocent[i_track-p_env->gen.i_first_track].track_format;
 }
 
-/*!
+/**
   Return true if we have XA data (green, mode2 form1) or
   XA data (green, mode2 form2). That is track begins:
   sync - header - subheader
@@ -1241,7 +1241,7 @@ _get_track_green_cdrdao(void *user_data, track_t i_track)
   return env->tocent[i_track-env->gen.i_first_track].track_green;
 }
 
-/*!
+/**
   Return the starting LSN track number
   i_track in obj.  Track numbers start at 1.
   The "leadout" track is specified either by
@@ -1263,7 +1263,7 @@ _get_lba_track_cdrdao(void *p_user_data, track_t i_track)
     return CDIO_INVALID_LBA;
 }
 
-/*!
+/**
   Check that a TOC file is valid. We parse the entire file.
 
 */
@@ -1285,7 +1285,7 @@ cdio_is_tocfile(const char *psz_cue_name)
   return false;
 }
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.
@@ -1299,7 +1299,7 @@ cdio_open_am_cdrdao (const char *psz_source_name, const char *psz_access_mode)
   return cdio_open_cdrdao(psz_source_name);
 }
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.

--- a/lib/driver/image/nrg.c
+++ b/lib/driver/image/nrg.c
@@ -16,7 +16,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/*! This code implements low-level access functions for the Nero native
+/** This code implements low-level access functions for the Nero native
    CD-image format residing inside a disk file (*.nrg).
 */
 
@@ -841,7 +841,7 @@ parse_nrg (_img_private_t *p_env, const char *psz_nrg_name,
   return true;
 }
 
-/*!
+/**
   Initialize image structures.
  */
 static bool
@@ -872,7 +872,7 @@ _init_nrg (_img_private_t *p_env)
 
 }
 
-/*!
+/**
   Reads into buf the next size bytes.
   Returns -1 on error.
   Would be libc's seek() but we have to adjust for the extra track header
@@ -916,7 +916,7 @@ _lseek_nrg (void *p_user_data, off_t offset, int whence)
   return cdio_stream_seek(p_env->gen.data_source, real_offset, whence);
 }
 
-/*!
+/**
   Reads into buf the next size bytes.
   Returns -1 on error.
   FIXME:
@@ -930,7 +930,7 @@ _read_nrg (void *p_user_data, void *buf, size_t size)
   return cdio_stream_read(p_env->gen.data_source, buf, size, 1);
 }
 
-/*!
+/**
   Get the size of the CD in logical block address (LBA) units.
 
   @param p_cdio the CD object queried
@@ -944,7 +944,7 @@ get_disc_last_lsn_nrg (void *p_user_data)
   return p_env->size;
 }
 
-/*!
+/**
    Reads a single audio sector from CD device into data starting
    from LSN.
  */
@@ -1050,7 +1050,7 @@ _read_mode1_sector_nrg (void *p_user_data, void *data, lsn_t lsn,
   return 0;
 }
 
-/*!
+/**
    Reads nblocks of mode2 sectors from cd device into data starting
    from lsn.
  */
@@ -1122,7 +1122,7 @@ _read_mode2_sector_nrg (void *p_user_data, void *data, lsn_t lsn,
   return 0;
 }
 
-/*!
+/**
    Reads nblocks of mode2 sectors from cd device into data starting
    from lsn.
    Returns 0 if no error.
@@ -1162,7 +1162,7 @@ _free_nrg (void *p_user_data)
   _free_image(p_user_data);
 }
 
-/*!
+/**
   Eject media -- there's nothing to do here except free resources.
   We always return 2.
  */
@@ -1208,7 +1208,7 @@ static void Win32Glob(const char* pattern, const char* szCurPath, char ***drives
 }
 #endif
 
-/*!
+/**
   Return an array of strings giving possible NRG disk images.
  */
 char **
@@ -1236,7 +1236,7 @@ cdio_get_devices_nrg (void)
   return drives;
 }
 
-/*!
+/**
   Return a string containing the default CD device.
  */
 char *
@@ -1264,7 +1264,7 @@ get_hwinfo_nrg ( const CdIo *p_cdio, /*out*/ cdio_hwinfo_t *hw_info)
 
 }
 
-/*!
+/**
   Return the number of tracks in the current medium.
   CDIO_INVALID_TRACK is returned on error.
 */
@@ -1290,7 +1290,7 @@ get_track_format_nrg(void *p_user_data, track_t track_num)
   return p_env->tocent[track_num-1].track_format;
 }
 
-/*!
+/**
   Return true if we have XA data (green, mode2 form1) or
   XA data (green, mode2 form2). That is track begins:
   sync - header - subheader
@@ -1310,7 +1310,7 @@ _get_track_green_nrg(void *p_user_data, track_t track_num)
   return p_env->tocent[track_num-1].track_green;
 }
 
-/*!
+/**
   Check that a NRG file is valid.
 */
 bool
@@ -1349,7 +1349,7 @@ cdio_is_nrg(const char *psz_nrg)
   return is_nrg;
 }
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.

--- a/lib/driver/image_common.c
+++ b/lib/driver/image_common.c
@@ -16,7 +16,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/*! Common image routines.
+/** Common image routines.
 
   Because _img_private_t may vary over image formats, the routines are
   included into the image drivers after _img_private_t is defined.  In
@@ -38,7 +38,7 @@
 #include <string.h>
 #endif
 
-/*!
+/**
   Eject media -- there's nothing to do here except free resources.
   We always return DRIVER_OP_UNSUPPORTED.
  */
@@ -49,7 +49,7 @@ _eject_media_image(void *p_user_data)
   return DRIVER_OP_UNSUPPORTED;
 }
 
-/*!
+/**
   We don't need the image any more. Free all memory associated with
   it.
  */
@@ -76,7 +76,7 @@ _free_image (void *p_user_data)
   free(p_env);
 }
 
-/*!
+/**
   Return the value associated with the key "arg".
 */
 const char *
@@ -107,7 +107,7 @@ _get_arg_image (void *user_data, const char key[])
   return NULL;
 }
 
-/*!
+/**
   Return CD-Text object
  */
 cdtext_t *
@@ -121,7 +121,7 @@ _get_cdtext_image (void *user_data)
   return p_env->cdtext;
 }
 
-/*!
+/**
   Get disc type associated with cd_obj.
 */
 discmode_t
@@ -131,7 +131,7 @@ _get_discmode_image (void *p_user_data)
   return p_env->disc_mode;
 }
 
-/*!
+/**
   Return the the kind of drive capabilities of device.
 
  */
@@ -160,7 +160,7 @@ _get_drive_cap_image (const void *user_data,
   *p_misc_cap  = CDIO_DRIVE_CAP_MISC_FILE;
 }
 
-/*!
+/**
   Return the number of of the first track.
   CDIO_INVALID_TRACK is returned on error.
 */
@@ -175,7 +175,7 @@ _get_first_track_num_image(void *p_user_data)
   return p_env->gen.toc_init ? p_env->gen.i_first_track : CDIO_INVALID_TRACK;
 }
 
-/*!
+/**
   Find out if media has changed since the last call.
   @param p_user_data the CD object to be acted upon.
   @return 1 if media has changed since last call, 0 if not. Error
@@ -189,7 +189,7 @@ get_media_changed_image(const void *p_user_data)
   return 0;
 }
 
-/*!
+/**
   Return the media catalog number (MCN) from the CD or NULL if there
   is none or we don't have the ability to get it.
 
@@ -205,7 +205,7 @@ _get_mcn_image(const void *p_user_data)
   return strdup(p_env->psz_mcn);
 }
 
-/*!
+/**
   Return the number of tracks.
 */
 track_t
@@ -216,7 +216,7 @@ _get_num_tracks_image(void *p_user_data)
   return p_env->gen.i_tracks;
 }
 
-/*!
+/**
   Return the starting MSF (minutes/secs/frames) for the track number
   track_num in obj.  Tracks numbers start at 1.
   The "leadout" track is specified either by
@@ -241,7 +241,7 @@ _get_track_msf_image(void *p_user_data, track_t i_track, msf_t *msf)
     return false;
 }
 
-/*! Return number of channels in track: 2 or 4; -2 if not
+/** Return number of channels in track: 2 or 4; -2 if not
   implemented or -1 for error.
   Not meaningful if track is not an audio track.
 */
@@ -253,7 +253,7 @@ get_track_channels_image(const void *p_user_data, track_t i_track)
 	  & FOUR_CHANNEL_AUDIO ) ? 4 : 2;
 }
 
-/*! Return 1 if copy is permitted on the track, 0 if not, or -1 for error.
+/** Return 1 if copy is permitted on the track, 0 if not, or -1 for error.
   Is this meaningful if not an audio track?
 */
 track_flag_t
@@ -264,7 +264,7 @@ get_track_copy_permit_image(void *p_user_data, track_t i_track)
 	   & COPY_PERMITTED ) ? CDIO_TRACK_FLAG_TRUE : CDIO_TRACK_FLAG_FALSE;
 }
 
-/*! Return 1 if track has pre-emphasis, 0 if not, or -1 for error.
+/** Return 1 if track has pre-emphasis, 0 if not, or -1 for error.
   Is this meaningful if not an audio track?
 
   pre-emphasis is a non linear frequency response.
@@ -277,7 +277,7 @@ get_track_preemphasis_image(const void *p_user_data, track_t i_track)
 	   & PRE_EMPHASIS ) ? CDIO_TRACK_FLAG_TRUE : CDIO_TRACK_FLAG_FALSE;
 }
 
-/*! Return the starting LBA for the pregap for track number i_track.
+/** Return the starting LBA for the pregap for track number i_track.
   Track numbers start at 1.
   CDIO_INVALID_LBA is returned on error.
 */
@@ -301,7 +301,7 @@ get_track_pregap_lba_image(const void *p_user_data, track_t i_track)
   return pregap;
 }
 
-/*!
+/**
   Return the International Standard Recording Code (ISRC) for track number
   i_track in p_cdio.  Track numbers start at 1.
 
@@ -321,7 +321,7 @@ get_track_isrc_image(const void *p_user_data, track_t i_track)
   }
 }
 
-/*!
+/**
   Read a data sector
 
   @param p_cdio object to read from
@@ -368,7 +368,7 @@ read_data_sectors_image ( void *p_user_data, void *p_buf,
 }
 
 
-/*!
+/**
   Set the arg "key" with "value" in the source device.
   Currently "source" to set the source device in I/O operations
   is the only valid key.

--- a/lib/driver/image_common.h
+++ b/lib/driver/image_common.h
@@ -15,7 +15,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/*! Common image routines.
+/** Common image routines.
 
   Because _img_private_t may vary over image formats, the routines are
   included into the image drivers after _img_private_t is defined.  In
@@ -60,7 +60,7 @@ typedef struct {
 #endif
 } _img_private_t;
 
-/*!
+/**
   We don't need the image any more. Free all memory associated with
   it.
  */
@@ -68,22 +68,22 @@ void  _free_image (void *p_user_data);
 
 driver_return_code_t _eject_media_image(void *p_user_data);
 
-/*!
+/**
   Return the value associated with the key "arg".
 */
 const char * _get_arg_image (void *user_data, const char key[]);
 
-/*!
+/**
   Return CD-Text object or NULL
  */
 cdtext_t * _get_cdtext_image(void *p_user_data);
 
-/*!
+/**
   Get disc type associated with cd_obj.
 */
 discmode_t _get_discmode_image (void *p_user_data);
 
-/*!
+/**
   Return the the kind of drive capabilities of device.
 
  */
@@ -92,13 +92,13 @@ void _get_drive_cap_image (const void *user_data,
                            cdio_drive_write_cap_t *p_write_cap,
                            cdio_drive_misc_cap_t  *p_misc_cap);
 
-/*!
+/**
   Return the number of of the first track.
   CDIO_INVALID_TRACK is returned on error.
 */
 track_t _get_first_track_num_image(void *p_user_data);
 
-/*!
+/**
   Find out if media has changed since the last call.
   @param p_user_data the CD object to be acted upon.
   @return 1 if media has changed since last call, 0 if not. Error
@@ -107,7 +107,7 @@ track_t _get_first_track_num_image(void *p_user_data);
  */
 int get_media_changed_image(const void *p_user_data);
 
-/*!
+/**
   Return the media catalog number (MCN) from the CD or NULL if there
   is none or we don't have the ability to get it.
 
@@ -116,13 +116,13 @@ int get_media_changed_image(const void *p_user_data);
   */
 char * _get_mcn_image(const void *p_user_data);
 
-/*!
+/**
   Return the number of tracks.
 */
 track_t _get_num_tracks_image(void *p_user_data);
 
 
-/*!
+/**
   Return the starting MSF (minutes/secs/frames) for the track number
   track_num in obj.  Tracks numbers start at 1.
   The "leadout" track is specified either by
@@ -131,18 +131,18 @@ track_t _get_num_tracks_image(void *p_user_data);
 */
 bool _get_track_msf_image(void *p_user_data, track_t i_track, msf_t *msf);
 
-/*! Return number of channels in track: 2 or 4; -2 if not
+/** Return number of channels in track: 2 or 4; -2 if not
   implemented or -1 for error.
   Not meaningful if track is not an audio track.
 */
 int get_track_channels_image(const void *p_user_data, track_t i_track);
 
-/*! Return 1 if copy is permitted on the track, 0 if not, or -1 for error.
+/** Return 1 if copy is permitted on the track, 0 if not, or -1 for error.
   Is this meaningful if not an audio track?
 */
 track_flag_t get_track_copy_permit_image(void *p_user_data, track_t i_track);
 
-/*! Return 1 if track has pre-emphasis, 0 if not, or -1 for error.
+/** Return 1 if track has pre-emphasis, 0 if not, or -1 for error.
   Is this meaningful if not an audio track?
 
   pre-emphasis is a non linear frequency response.
@@ -150,13 +150,13 @@ track_flag_t get_track_copy_permit_image(void *p_user_data, track_t i_track);
 track_flag_t get_track_preemphasis_image(const void *p_user_data,
                                          track_t i_track);
 
-/*! Return the starting LBA for the pregap for track number i_track.
+/** Return the starting LBA for the pregap for track number i_track.
   Track numbers start at 1.
   CDIO_INVALID_LBA is returned on error.
 */
 lba_t get_track_pregap_lba_image(const void *p_user_data, track_t i_track);
 
-/*!
+/**
   Return the International Standard Recording Code (ISRC) for track number
   i_track in p_cdio.  Track numbers start at 1.
 
@@ -165,7 +165,7 @@ lba_t get_track_pregap_lba_image(const void *p_user_data, track_t i_track);
 */
 char *get_track_isrc_image(const void *p_user_data, track_t i_track);
 
-/*!
+/**
   Read a data sector
 
   @param p_cdio object to read from
@@ -190,7 +190,7 @@ read_data_sectors_image ( void *p_user_data, void *p_buf,
                           lsn_t i_lsn,  uint16_t i_blocksize,
                           uint32_t i_blocks );
 
-/*!
+/**
   Set the arg "key" with "value" in the source device.
   Currently "source" to set the source device in I/O operations
   is the only valid key.

--- a/lib/driver/memory.c
+++ b/lib/driver/memory.c
@@ -28,7 +28,7 @@
 #include <cdio/memory.h>
 #include <cdio/types.h>
 
-/*!
+/**
   Free the passed pointer.
 
   @param p_memory a pointer to memory allocated by a libcdio function.

--- a/lib/driver/mmc/mmc_private.h
+++ b/lib/driver/mmc/mmc_private.h
@@ -17,7 +17,7 @@
 
 #include <cdio/mmc.h>
 
-/*! Convert milliseconds to seconds taking the ceiling value, i.e.
+/** Convert milliseconds to seconds taking the ceiling value, i.e.
     1002 milliseconds gets rounded to 2 seconds.
 */
 #define SECS2MSECS 1000
@@ -32,7 +32,7 @@ msecs2secs(unsigned int msecs)
   MMC CdIo Operations which a driver may use.
   These are not directly user-accessible.
 ************************************************************/
-/*!
+/**
   Read Audio Subchannel information
 
   @param p_user_data the CD object to be acted upon.
@@ -42,13 +42,13 @@ driver_return_code_t
 audio_read_subchannel_mmc ( void *p_user_data,
 			    cdio_subchannel_t *p_subchannel);
 
-/*!
+/**
   Get the block size for subsequent read requests, via a SCSI MMC
   MODE_SENSE 6 command.
 */
 int get_blocksize_mmc (void *p_user_data);
 
-/*!
+/**
   Get the lsn of the end of the CD
 
   @return the lsn. On error return CDIO_INVALID_LSN.
@@ -67,7 +67,7 @@ char *get_track_isrc_mmc (const void *p_user_data, track_t i_track);
 
 driver_return_code_t get_tray_status (const void *p_user_data);
 
-/*! Read just the user data part of some sort of data sector (via
+/** Read just the user data part of some sort of data sector (via
     mmc_read_cd).
 
     @param p_user_data object to read from
@@ -118,7 +118,7 @@ int mmc_set_blocksize_mmc_private ( const void *p_env, const
 				    mmc_run_cmd_fn_t run_mmc_cmd,
 				    uint16_t i_blocksize );
 
-/*!
+/**
   Get the DVD type associated with cd object.
 */
 discmode_t
@@ -126,7 +126,7 @@ mmc_get_dvd_struct_physical_private ( void *p_env,
 				      mmc_run_cmd_fn_t run_mmc_cmd,
 				      cdio_dvd_struct_t *s );
 
-/*!
+/**
   On input a MODE_SENSE command was issued and we have the results
   in p. We interpret this and return a bit mask set according to the
   capabilities.

--- a/lib/driver/mmc/mmc_util.c
+++ b/lib/driver/mmc/mmc_util.c
@@ -78,7 +78,7 @@ uint32_t mmc_timeout_ms = MMC_TIMEOUT_DEFAULT;
 */
 uint32_t mmc_read_timeout_ms = MMC_READ_TIMEOUT_DEFAULT;
 
-/*!
+/**
   Return a string containing the name of the audio state as returned from
   the Q_SUBCHANNEL.
  */

--- a/lib/driver/netbsd.c
+++ b/lib/driver/netbsd.c
@@ -205,7 +205,7 @@ read_audio_sectors_netbsd(void *user_data, void *data, lsn_t lsn,
         return 0;
 }
 
-/*!
+/**
    Reads a single mode1 sector from cd device into data starting
    from lsn. Returns 0 if no error.
  */
@@ -217,7 +217,7 @@ _read_mode1_sector_netbsd (void *p_user_data, void *p_data, lsn_t lsn,
   return cdio_generic_read_form1_sector(p_user_data, p_data, lsn);
 }
 
-/*!
+/**
    Reads i_blocks of mode2 sectors from cd device into data starting
    from lsn.
    Returns 0 if no error.
@@ -454,7 +454,7 @@ is_mmc_supported(void *user_data)
     return (_AM_NONE == env->access_mode) ? false : true;
 }
 
-/*!
+/**
   Return the value associated with the key "arg".
 */
 static const char *
@@ -513,7 +513,7 @@ get_num_tracks_netbsd(void *user_data)
         return TOTAL_TRACKS;
 }
 
-/*!
+/**
   Return the international standard recording code ISRC.
 
   Note: string is malloc'd so caller should free() then returned
@@ -562,7 +562,7 @@ audio_set_volume_netbsd(void *p_user_data, cdio_audio_volume_t *p_volume)
   return (ioctl(p_env->gen.fd, CDIOCSETVOL, p_volume));
 }
 
-/*!
+/**
   Get format of track.
 */
 static track_format_t
@@ -603,7 +603,7 @@ get_track_format_netbsd(void *user_data, track_t track_num)
                 return TRACK_FORMAT_AUDIO;
 }
 
-/*!
+/**
   Return true if we have XA data (green, mode2 form1) or
   XA data (green, mode2 form2). That is track begins:
   sync - header - subheader
@@ -619,7 +619,7 @@ get_track_green_netbsd(void *user_data, track_t track_num)
                 == TRACK_FORMAT_XA);
 }
 
-/*!
+/**
   Return the starting MSF (minutes/secs/frames) for track number
   track_num in obj.  Track numbers usually start at something
   greater than 0, usually 1.
@@ -662,7 +662,7 @@ get_track_msf_netbsd(void *user_data, track_t track_num, msf_t *msf)
         return true;
 }
 
-/*!
+/**
    Return the size of the CD in logical block address (LBA) units.
    @return the lsn. On error return CDIO_INVALID_LSN.
 
@@ -785,7 +785,7 @@ audio_read_subchannel_netbsd(void *p_user_data, cdio_subchannel_t *subchannel)
 #endif
 #endif /* HAVE_NETBSD_CDROM */
 
-/*!
+/**
   Return a string containing the default CD device.
  */
 char *
@@ -794,7 +794,7 @@ cdio_get_default_device_netbsd(void)
   return strdup(DEFAULT_CDIO_DEVICE);
 }
 
-/*!
+/**
   Close tray on CD-ROM.
 
   @param psz_device the CD-ROM drive to be closed.
@@ -865,7 +865,7 @@ static cdio_funcs_t _funcs = {
 };
 #endif /*HAVE_NETBSD_CDROM*/
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.
@@ -921,7 +921,7 @@ cdio_open_netbsd(const char *source_name)
 
 }
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.

--- a/lib/driver/read.c
+++ b/lib/driver/read.c
@@ -74,7 +74,7 @@
     }                                                                    \
   }
 
-/*!
+/**
   lseek - reposition read/write file offset
   Returns (off_t) -1 on error.
   Similar to (if not the same as) libc's lseek()
@@ -89,7 +89,7 @@ cdio_lseek (const CdIo_t *p_cdio, off_t offset, int whence)
   return DRIVER_OP_UNSUPPORTED;
 }
 
-/*!  Reads into buf the next size bytes.  Similar to (if not the
+/**  Reads into buf the next size bytes.  Similar to (if not the
   same as) libc's read(). This is a "cooked" read, or one handled by
   the OS. It probably won't work on audio data. For that use
   cdio_read_audio_sector(s).
@@ -111,7 +111,7 @@ cdio_read (const CdIo_t *p_cdio, void *p_buf, size_t i_size)
   return DRIVER_OP_UNSUPPORTED;
 }
 
-/*!
+/**
   Reads an audio sector from cd device into data starting
   from lsn. Returns DRIVER_OP_SUCCESS if no error.
 */
@@ -124,7 +124,7 @@ cdio_read_audio_sector (const CdIo_t *p_cdio, void *p_buf, lsn_t i_lsn)
   return DRIVER_OP_UNSUPPORTED;
 }
 
-/*!
+/**
   Reads audio sectors from cd device into data starting
   from lsn. Returns DRIVER_OP_SUCCESS if no error.
 */
@@ -145,7 +145,7 @@ cdio_read_audio_sectors (const CdIo_t *p_cdio, void *p_buf, lsn_t i_lsn,
   return DRIVER_OP_UNSUPPORTED;
 }
 
-/*!
+/**
   Reads an audio sector from cd device into data starting
   from lsn. Returns DRIVER_OP_SUCCESS if no error.
 */
@@ -171,7 +171,7 @@ cdio_read_data_sectors (const CdIo_t *p_cdio, void *p_buf, lsn_t i_lsn,
 #define SEEK_SET 0
 #endif
 
-/*!
+/**
    Reads a single mode1 form1 or form2  sector from cd device
    into data starting from lsn. Returns DRIVER_OP_SUCCESS if no error.
  */
@@ -198,7 +198,7 @@ cdio_read_mode1_sector (const CdIo_t *p_cdio, void *p_buf, lsn_t i_lsn,
   return DRIVER_OP_UNSUPPORTED;
 }
 
-/*!
+/**
   Reads mode 1 sectors
 
   @param p_cdio object to read from
@@ -222,7 +222,7 @@ cdio_read_mode1_sectors (const CdIo_t *p_cdio, void *p_buf, lsn_t i_lsn,
   return DRIVER_OP_UNSUPPORTED;
 }
 
-/*!
+/**
   Reads a mode 2 sector
 
   @param p_cdio object to read from
@@ -245,7 +245,7 @@ cdio_read_mode2_sector (const CdIo_t *p_cdio, void *p_buf, lsn_t i_lsn,
   return DRIVER_OP_UNSUPPORTED;
 }
 
-/*!
+/**
   Reads mode 2 sectors
 
   @param p_cdio object to read from
@@ -281,7 +281,7 @@ cdio_read_sector(const CdIo_t *p_cdio, void *p_buf, lsn_t i_lsn,
   return cdio_read_sectors(p_cdio, p_buf, i_lsn, read_mode, 1);
 }
 
-/*!
+/**
   Reads a number of sectors (AKA blocks).
 
   @param p_buf place to read data into. The caller should make sure

--- a/lib/driver/realpath.c
+++ b/lib/driver/realpath.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 2010, 2011
   Rocky Bernstein <rocky@gnu.org>
-  Diego 'Flameeyes' Pettenò 
+  Diego 'Flameeyes' Pettenò
   Thomas Schmitt
 
   This program is free software: you can redistribute it and/or modify
@@ -66,7 +66,7 @@
 
 #include <cdio/util.h>
 
-/*!  cdio_realpath() same as POSIX.1-2001 realpath if that's
+/**  cdio_realpath() same as POSIX.1-2001 realpath if that's
 around. If not we do poor-man's simulation of that behavior.  */
 char *cdio_realpath (const char *psz_src_path, char *psz_resolved_path) {
 
@@ -82,10 +82,10 @@ char *cdio_realpath (const char *psz_src_path, char *psz_resolved_path) {
 
   strcpy(tmp_src, psz_src_path);
 
-  /* FIXME: 
-     remove loop and change with stat before and after readlink 
+  /* FIXME:
+     remove loop and change with stat before and after readlink
      which looks direct symlink. Rely on errno to figure out other
-     non-existent or looped symlinks. 
+     non-existent or looped symlinks.
   */
   for(i = 0; i < loop_limit; i++) {
     len = readlink(tmp_src, tmp_dst, PATH_MAX);
@@ -117,7 +117,7 @@ char *cdio_realpath (const char *psz_src_path, char *psz_resolved_path) {
 #endif
 
   return psz_resolved_path;
-  
+
 }
 
 #ifdef STANDALONE

--- a/lib/driver/sector.c
+++ b/lib/driver/sector.c
@@ -37,7 +37,7 @@
 
 #include <ctype.h>
 
-/*! String of bytes used to identify the beginning of a Mode 1 or
+/** String of bytes used to identify the beginning of a Mode 1 or
   Mode 2 sector. */
 const uint8_t CDIO_SECTOR_SYNC_HEADER[CDIO_CD_SYNC_SIZE] =
   {0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0};
@@ -89,7 +89,7 @@ cdio_lsn_to_msf (lsn_t lsn, msf_t *msf)
   msf->f = cdio_to_bcd8 (f);
 }
 
-/*!
+/**
   Convert an LBA into a string representation of the MSF.
   \warning cdio_lba_to_msf_str returns new allocated string */
 char *
@@ -106,7 +106,7 @@ cdio_lba_to_msf_str (lba_t lba)
   }
 }
 
-/*!
+/**
   Convert an LSN into the corresponding LBA.
   CDIO_INVALID_LBA is returned if there is an error.
 */
@@ -117,7 +117,7 @@ cdio_lsn_to_lba (lsn_t lsn)
   return lsn + CDIO_PREGAP_SECTORS;
 }
 
-/*!
+/**
   Convert an LBA into the corresponding MSF.
 */
 void
@@ -127,7 +127,7 @@ cdio_lba_to_msf (lba_t lba, msf_t *msf)
   cdio_lsn_to_msf(cdio_lba_to_lsn(lba), msf);
 }
 
-/*!
+/**
   Convert a MSF into the corresponding LBA.
   CDIO_INVALID_LBA is returned if there is an error.
 */
@@ -149,7 +149,7 @@ cdio_msf_to_lba (const msf_t *msf)
   return lba;
 }
 
-/*!
+/**
   Convert a MSF into the corresponding LSN.
   CDIO_INVALID_LSN is returned if there is an error.
 */
@@ -159,7 +159,7 @@ cdio_msf_to_lsn (const msf_t *msf)
   return cdio_lba_to_lsn(cdio_msf_to_lba (msf));
 }
 
-/*!
+/**
   Convert an LBA into a string representation of the MSF.
   \warning cdio_lba_to_msf_str returns new allocated string */
 char *
@@ -171,7 +171,7 @@ cdio_msf_to_str (const msf_t *msf)
   return strdup (buf);
 }
 
-/*!
+/**
   Convert a MSF - broken out as 3 integer components into the
   corresponding LBA.
   CDIO_INVALID_LBA is returned if there is an error.
@@ -184,7 +184,7 @@ cdio_msf3_to_lba (unsigned int minutes, unsigned int seconds,
 	  + frames);
 }
 
-/*!
+/**
   Convert a string of the form MM:SS:FF into the corresponding LBA.
   CDIO_INVALID_LBA is returned if there is an error.
 */

--- a/lib/driver/solaris.c
+++ b/lib/driver/solaris.c
@@ -97,7 +97,7 @@ typedef struct {
   struct cdrom_tochdr    tochdr;
 } _img_private_t;
 
-/*!
+/**
   Return the international standard recording code ISRC.
 
   Note: string is malloc'd so caller should free() then returned
@@ -137,7 +137,7 @@ str_to_access_mode_solaris(const char *psz_access_mode)
 }
 
 
-/*!
+/**
   Pause playing CD through analog output
 
   @param p_cdio the CD object to be acted upon.
@@ -150,7 +150,7 @@ audio_pause_solaris (void *p_user_data)
   return ioctl(p_env->gen.fd, CDROMPAUSE);
 }
 
-/*!
+/**
   Playing starting at given MSF through analog output
 
   @param p_cdio the CD object to be acted upon.
@@ -173,7 +173,7 @@ audio_play_msf_solaris (void *p_user_data, msf_t *p_start_msf,
   return ioctl(p_env->gen.fd, CDROMPLAYMSF, &solaris_msf);
 }
 
-/*!
+/**
   Playing CD through analog output at the desired track and index
 
   @param p_cdio the CD object to be acted upon.
@@ -188,7 +188,7 @@ audio_play_track_index_solaris (void *p_user_data,
   return ioctl(p_env->gen.fd, CDROMPLAYTRKIND, p_track_index);
 }
 
-/*!
+/**
   Read Audio Subchannel information
 
   @param p_cdio the CD object to be acted upon.
@@ -229,7 +229,7 @@ audio_read_subchannel_solaris (void *p_user_data,
   }
 }
 
-/*!
+/**
   Resume playing an audio CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -243,7 +243,7 @@ audio_resume_solaris (void *p_user_data)
   return ioctl(p_env->gen.fd, CDROMRESUME, 0);
 }
 
-/*!
+/**
   Resume playing an audio CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -257,7 +257,7 @@ audio_set_volume_solaris (void *p_user_data,
   return ioctl(p_env->gen.fd, CDROMVOLCTRL, p_volume);
 }
 
-/*!
+/**
   Stop playing an audio CD.
 
   @param p_user_data the CD object to be acted upon.
@@ -334,7 +334,7 @@ set_scsi_tuple_solaris (_img_private_t *p_env)
   return 1;
 }
 
-/*!
+/**
   Initialize CD device.
  */
 static bool
@@ -353,7 +353,7 @@ init_solaris (_img_private_t *p_env)
   return true;
 }
 
-/*!
+/**
   Run a SCSI MMC command.
 
   p_user_data   internal CD structure.
@@ -442,7 +442,7 @@ run_mmc_cmd_solaris(void *p_user_data, unsigned int i_timeout_ms,
     return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
    Reads audio sectors from CD device into data starting from lsn.
    Returns 0 if no error.
 
@@ -494,7 +494,7 @@ _read_audio_sectors_solaris (void *p_user_data, void *data, lsn_t i_lsn,
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
    Reads a single mode1 sector from cd device into data starting
    from i_lsn.
  */
@@ -510,7 +510,7 @@ _read_mode1_sector_solaris (void *p_env, void *data, lsn_t i_lsn,
 #endif
 }
 
-/*!
+/**
    Reads i_blocks of mode2 sectors from cd device into data starting
    from i_lsn.
  */
@@ -532,7 +532,7 @@ _read_mode1_sectors_solaris (void *p_user_data, void *p_data, lsn_t i_lsn,
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
    Reads a single mode2 sector from cd device into data starting from lsn.
  */
 static driver_return_code_t
@@ -590,7 +590,7 @@ _read_mode2_sector_solaris (void *p_user_data, void *p_data, lsn_t i_lsn,
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
    Reads i_blocks of mode2 sectors from cd device into data starting
    from i_lsn.
  */
@@ -613,7 +613,7 @@ _read_mode2_sectors_solaris (void *p_user_data, void *data, lsn_t i_lsn,
 }
 
 
-/*!
+/**
    Return the size of the CD in logical block address (LBA) units.
    @return the size. On error return CDIO_INVALID_LSN.
  */
@@ -638,7 +638,7 @@ get_disc_last_lsn_solaris (void *p_user_data)
   return size;
 }
 
-/*!
+/**
   Set the arg "key" with "value" in the source device.
   Currently "source" and "access-mode" are valid keys.
   "source" sets the source device in I/O operations
@@ -667,7 +667,7 @@ _set_arg_solaris (void *p_user_data, const char key[], const char value[])
   return DRIVER_OP_SUCCESS;
 }
 
-/*!
+/**
   Read and cache the CD's Track Table of Contents and track info.
   Return true if successful or false if an error.
 */
@@ -720,7 +720,7 @@ read_toc_solaris (void *p_user_data)
   return true;
 }
 
-/*!
+/**
   Eject media in CD drive. If successful, as a side effect we
   also free obj.
  */
@@ -751,7 +751,7 @@ is_mmc_supported(void *user_data)
     return (_AM_NONE == env->access_mode) ? false : true;
 }
 
-/*!
+/**
   Return the value associated with the key "arg".
 */
 static const char *
@@ -782,7 +782,7 @@ get_arg_solaris (void *p_user_data, const char key[])
   return NULL;
 }
 
-/*!
+/**
   Get the block size used in read requests, via ioctl.
   @return the blocksize if > 0; error if <= 0
  */
@@ -803,7 +803,7 @@ get_blocksize_solaris (void *p_user_data) {
 }
 
 #ifdef HAVE_SOLARIS_CDROM
-/*!
+/**
   Return a string containing the default CD device if none is specified.
   This call does not assume a fixed default drive address but rather uses
   the first drive that gets enumerated by cdio_get_devices_solaris_cXtYdZs2().
@@ -825,7 +825,7 @@ cdio_get_default_cXtYdZs2(void)
 }
 #endif
 
-/*!
+/**
   Return a string containing the default CD device if none is specified.
  */
 char *
@@ -870,7 +870,7 @@ cdio_get_default_device_solaris(void)
   return strdup(DEFAULT_CDIO_DEVICE);
 }
 
-/*!
+/**
   Get disc type associated with cd object.
 */
 
@@ -989,7 +989,7 @@ get_discmode_solaris (void *p_user_data)
   return discmode;
 }
 
-/*!
+/**
   Return the session number of the last on the CD.
 
   @param p_cdio the CD object to be acted upon.
@@ -1011,7 +1011,7 @@ get_last_session_solaris (void *p_user_data,
   }
 }
 
-/*!
+/**
   Get format of track.
 */
 static track_format_t
@@ -1044,7 +1044,7 @@ get_track_format_solaris(void *p_user_data, track_t i_track)
 
 }
 
-/*!
+/**
   Return true if we have XA data (green, mode2 form1) or
   XA data (green, mode2 form2). That is track begins:
   sync - header - subheader
@@ -1073,7 +1073,7 @@ get_track_green_solaris(void *p_user_data, track_t i_track)
   return ((p_env->tocent[i_track].cdte_ctrl & 2) != 0);
 }
 
-/*!
+/**
   Return the starting MSF (minutes/secs/frames) for track number
   track_num in obj.  Track numbers usually start at something
   greater than 0, usually 1.
@@ -1107,7 +1107,7 @@ get_track_msf_solaris(void *p_user_data, track_t i_track, msf_t *msf)
   }
 }
 
-/*!
+/**
   Get the block size used in read requests, via ioctl.
   @return the blocksize if > 0; error if <= 0
  */
@@ -1137,7 +1137,7 @@ set_speed_solaris (void *p_user_data, int i_speed)
 }
 
 #else
-/*!
+/**
   Return a string containing the default VCD device if none is specified.
  */
 char *
@@ -1148,7 +1148,7 @@ cdio_get_default_device_solaris(void)
 
 #endif /* HAVE_SOLARIS_CDROM */
 
-/*!
+/**
   Close tray on CD-ROM.
 
   @param psz_device the CD-ROM drive to be closed.
@@ -1177,7 +1177,7 @@ close_tray_solaris (const char *psz_device)
 }
 
 #ifdef HAVE_SOLARIS_CDROM
-/*!
+/**
   Return an array of strings giving possible CD devices.
   New method after demise of vold in 2006.
  */
@@ -1285,7 +1285,7 @@ ex:;
 }
 #endif /*HAVE_SOLARIS_CDROM*/
 
-/*!
+/**
   Return an array of strings giving possible CD devices.
  */
 char **
@@ -1344,7 +1344,7 @@ cdio_get_devices_solaris (void)
 #endif /*HAVE_SOLARIS_CDROM*/
 }
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.
@@ -1355,7 +1355,7 @@ cdio_open_solaris (const char *psz_source_name)
   return cdio_open_am_solaris(psz_source_name, NULL);
 }
 
-/*!
+/**
   Initialization routine. This is the only thing that doesn't
   get called via a function pointer. In fact *we* are the
   ones to set that up.

--- a/lib/driver/track.c
+++ b/lib/driver/track.c
@@ -16,7 +16,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/*! Track-related routines. */
+/** Track-related routines. */
 
 
 #ifdef HAVE_CONFIG_H
@@ -39,7 +39,7 @@ const char *track_format2str[6] =
 /* Variables to hold debugger-helping enumerations */
 enum cdio_track_enums;
 
-/*!
+/**
   Return the number of the first track.
   CDIO_INVALID_TRACK is returned on error.
 */
@@ -59,7 +59,7 @@ cdio_get_first_track_num(const CdIo_t *p_cdio)
   }
 }
 
-/*!
+/**
   Return the last track number.
   CDIO_INVALID_TRACK is returned on error.
 */
@@ -82,7 +82,7 @@ cdio_get_last_track_num (const CdIo_t *p_cdio)
   }
 }
 
-/*! Return number of channels in track: 2 or 4; -2 if not
+/** Return number of channels in track: 2 or 4; -2 if not
   implemented or -1 for error.
   Not meaningful if track is not an audio track.
 */
@@ -107,7 +107,7 @@ cdio_get_track_channels(const CdIo_t *p_cdio, track_t u_track)
   }
 }
 
-/*! Return copy protection status on a track. Is this meaningful
+/** Return copy protection status on a track. Is this meaningful
   if not an audio track?
 */
 track_flag_t
@@ -120,7 +120,7 @@ cdio_get_track_copy_permit(const CdIo_t *p_cdio, track_t u_track)
   }
 }
 
-/*!
+/**
   Get format of track.
 */
 track_format_t
@@ -134,7 +134,7 @@ cdio_get_track_format(const CdIo_t *p_cdio, track_t u_track)
     return TRACK_FORMAT_ERROR;
   }
 }
-/*!
+/**
   Return the Joliet level recognized for p_cdio.
 */
 uint8_t
@@ -148,7 +148,7 @@ cdio_get_joliet_level(const CdIo_t *p_cdio)
   }
 }
 
-/*!
+/**
   Return the number of tracks in the current medium.
   CDIO_INVALID_TRACK is returned on error.
 */
@@ -164,7 +164,7 @@ cdio_get_num_tracks (const CdIo_t *p_cdio)
   }
 }
 
-/*! Find the track which contains lsn.
+/** Find the track which contains lsn.
     CDIO_INVALID_TRACK is returned if the lsn outside of the CD or
     if there was some error.
 
@@ -208,7 +208,7 @@ cdio_get_track(const CdIo_t *p_cdio, lsn_t lsn)
   }
 }
 
-/*!
+/**
   Return true if we have XA data (green, mode2 form1) or
   XA data (green, mode2 form2). That is track begins:
   sync - header - subheader
@@ -230,7 +230,7 @@ cdio_get_track_green(const CdIo_t *p_cdio, track_t u_track)
   }
 }
 
-/*!
+/**
   Return the starting LBA for track number
   track_num in cdio.  Tracks numbers start at 1.
   The "leadout" track is specified either by
@@ -256,7 +256,7 @@ cdio_get_track_lba(const CdIo_t *p_cdio, track_t u_track)
   }
 }
 
-/*!
+/**
   Return the starting LSN for track number
   u_track in cdio.  Tracks numbers start at 1.
   The "leadout" track is specified either by
@@ -290,7 +290,7 @@ cdio_get_track_lsn(const CdIo_t *p_cdio, track_t u_track)
   }
 }
 
-/*!
+/**
   Return the International Standard Recording Code (ISRC) for track number
   u_track in p_cdio.  Track numbers start at 1.
 
@@ -320,7 +320,7 @@ cdio_get_track_isrc (const CdIo_t *p_cdio, track_t u_track)
   }
 }
 
-/*!
+/**
   Return the starting LBA for the pregap for track number
   u_track in cdio.  Track numbers start at 1.
   CDIO_INVALID_LBA is returned on error.
@@ -340,7 +340,7 @@ cdio_get_track_pregap_lba(const CdIo_t *p_cdio, track_t u_track)
   }
 }
 
-/*!
+/**
   Return the starting LSN for the pregap for track number
   u_track in cdio.  Track numbers start at 1.
   CDIO_INVALID_LSN is returned on error.
@@ -351,7 +351,7 @@ cdio_get_track_pregap_lsn(const CdIo_t *p_cdio, track_t u_track)
   return cdio_lba_to_lsn(cdio_get_track_pregap_lba(p_cdio, u_track));
 }
 
-/*!
+/**
   Return the ending LSN for track number
   u_track in cdio.  CDIO_INVALID_LSN is returned on error.
 */
@@ -365,7 +365,7 @@ cdio_get_track_last_lsn(const CdIo_t *p_cdio, track_t u_track)
   return lsn - 1;
 }
 
-/*!
+/**
   Return the starting MSF (minutes/secs/frames) for track number
   u_track in cdio.  Track numbers start at 1.
   The "leadout" track is specified either by
@@ -389,7 +389,7 @@ cdio_get_track_msf(const CdIo_t *p_cdio, track_t u_track, /*out*/ msf_t *msf)
   }
 }
 
-/*! Return copy protection status on a track. Is this meaningful
+/** Return copy protection status on a track. Is this meaningful
   if not an audio track?
 */
 track_flag_t
@@ -402,7 +402,7 @@ cdio_get_track_preemphasis(const CdIo *p_cdio, track_t u_track)
   }
 }
 
-/*!
+/**
   Return the number of sectors between this track an the next.  This
   includes any pregap sectors before the start of the next track.
   Tracks start at 1.

--- a/lib/iso9660/iso9660.c
+++ b/lib/iso9660/iso9660.c
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/*! String inside frame which identifies an ISO 9660 filesystem. This
+/** String inside frame which identifies an ISO 9660 filesystem. This
     string is the "id" field of an iso9660_pvd_t or an iso9660_svd_t.
     Note should come *before* #include <cdio/iso9660.h> which does
     a #define of this name.
@@ -129,7 +129,7 @@ enum iso_extension_enum_s iso_extension_enums;
 #define SYSTEM_ID         "CD-RTOS CD-BRIDGE"
 #define VOLUME_SET_ID     ""
 
-/*!
+/**
    Change trailing blanks in str to nulls.  Str has a maximum size of
    n characters.
 */
@@ -159,7 +159,7 @@ static void
 pathtable_get_size_and_entries(const void *pt, unsigned int *size,
                                unsigned int *entries);
 
-/*!
+/**
   Get time structure from structure in an ISO 9660 directory index
   record. Even though tm_wday and tm_yday fields are not explicitly in
   idr_date, the are calculated from the other fields.
@@ -257,7 +257,7 @@ iso9660_get_dtime (const iso9660_dtime_t *idr_date, bool b_localtime,
     p_tm->TM_FIELD = tmp + ADD_CONSTANT;                                \
   }
 
-/*!
+/**
   Get "long" time in format used in ISO 9660 primary volume descriptor
   from a Unix time structure.
 */
@@ -301,7 +301,7 @@ iso9660_get_ltime (const iso9660_ltime_t *p_ldate,
   return true;
 }
 
-/*!
+/**
   Set time in format used in ISO 9660 directory index record
   from a Unix time structure. timezone is given as an offset
   correction in minutes.
@@ -338,7 +338,7 @@ iso9660_set_dtime_with_timezone (const struct tm *p_tm,
   }
 }
 
-/*!
+/**
   Set time in format used in ISO 9660 directory index record
   from a Unix time structure. */
 void
@@ -356,7 +356,7 @@ iso9660_set_dtime(const struct tm *p_tm, /*out*/ iso9660_dtime_t *p_idr_date)
   iso9660_set_dtime_with_timezone (p_tm, time_zone, p_idr_date);
 }
 
-/*!
+/**
   Set "long" time in format used in ISO 9660 primary volume descriptor
   from a Unix time structure. timezone is given as an offset
   correction in minutes.
@@ -396,7 +396,7 @@ iso9660_set_ltime_with_timezone(const struct tm *p_tm,
   }
 }
 
-/*!
+/**
   Set "long" time in format used in ISO 9660 primary volume descriptor
   from a Unix time structure. */
 void
@@ -414,7 +414,7 @@ iso9660_set_ltime(const struct tm *p_tm, /*out*/ iso9660_ltime_t *pvd_date)
   iso9660_set_ltime_with_timezone (p_tm, time_zone, pvd_date);
 }
 
-/*!
+/**
    Convert an ISO-9660 file name which is in the format usually stored
    in a ISO 9660 directory entry into what's usually listed as the
    file name in a listing.  Lowercase name, and remove trailing ;1's
@@ -432,7 +432,7 @@ iso9660_name_translate(const char *psz_oldname, char *psz_newname)
   return iso9660_name_translate_ext(psz_oldname, psz_newname, 0);
 }
 
-/*!
+/**
    Convert an ISO-9660 file name which is in the format usually stored
    in a ISO 9660 directory entry into what's usually listed as the
    file name in a listing.  Lowercase name if no Joliet Extension
@@ -482,7 +482,7 @@ iso9660_name_translate_ext(const char *psz_oldname, char *psz_newname,
   return i;
 }
 
-/*!
+/**
   Pad string src with spaces to size len and copy this to dst. If
   len is less than the length of src, dst will be truncated to the
   first len characters of src.
@@ -556,7 +556,7 @@ iso9660_strncpy_pad(char dst[], const char src[], size_t len,
   return dst;
 }
 
-/*!
+/**
    Return true if c is a DCHAR - a valid ISO-9660 level 1 character.
    These are the ASCSII capital letters A-Z, the digits 0-9 and an
    underscore.
@@ -573,7 +573,7 @@ iso9660_is_dchar (int c)
 }
 
 
-/*!
+/**
    Return true if c is an ACHAR -
    These are the DCHAR's plus some ASCII symbols including the space
    symbol.
@@ -842,7 +842,7 @@ iso9660_pathtable_init (void *pt)
   memset (pt, 0, ISO_BLOCKSIZE); /* fixme */
 }
 
-/*!
+/**
   Returns POSIX mode bitstring for a given file.
 */
 mode_t
@@ -997,7 +997,7 @@ iso9660_pathtable_m_add_entry (void *pt,
   return entrynum;
 }
 
-/*!
+/**
   Check that pathname is a valid ISO-9660 directory name.
 
   A valid directory name should not start out with a slash (/),
@@ -1042,7 +1042,7 @@ iso9660_dirname_valid_p (const char pathname[])
   return true;
 }
 
-/*!
+/**
   Check that pathname is a valid ISO-9660 pathname.
 
   A valid pathname contains a valid directory name, if one appears and
@@ -1112,7 +1112,7 @@ iso9660_pathname_valid_p (const char pathname[])
   return true;
 }
 
-/*!
+/**
   Take pathname and a version number and turn that into a ISO-9660
   pathname.  (That's just the pathname followed by ";" and the version
   number. For example, mydir/file.ext -> mydir/file.ext;1 for version
@@ -1130,7 +1130,7 @@ iso9660_pathname_isofy (const char pathname[], uint16_t version)
   return strdup (tmpbuf);
 }
 
-/*!
+/**
   Return the PVD's application ID.
   NULL is returned if there is some problem in getting this.
 */
@@ -1194,7 +1194,7 @@ iso9660_get_pvd_block_size(const iso9660_pvd_t *pvd)
   return from_723(pvd->logical_block_size);
 }
 
-/*! Return the primary volume id version number (of pvd).
+/** Return the primary volume id version number (of pvd).
     If there is an error 0 is returned.
  */
 int
@@ -1204,7 +1204,7 @@ iso9660_get_pvd_version(const iso9660_pvd_t *pvd)
   return pvd->version;
 }
 
-/*! Return the LSN of the root directory for pvd.
+/** Return the LSN of the root directory for pvd.
     If there is an error CDIO_INVALID_LSN is returned.
  */
 lsn_t
@@ -1219,7 +1219,7 @@ iso9660_get_root_lsn(const iso9660_pvd_t *pvd)
   }
 }
 
-/*!
+/**
    Return a string containing the preparer id with trailing
    blanks removed.
 */
@@ -1230,7 +1230,7 @@ iso9660_get_preparer_id(const iso9660_pvd_t *pvd)
   return strdup(strip_trail(pvd->preparer_id, ISO_MAX_PREPARER_ID));
 }
 
-/*!
+/**
    Return a string containing the publisher id with trailing
    blanks removed.
 */
@@ -1241,7 +1241,7 @@ iso9660_get_publisher_id(const iso9660_pvd_t *pvd)
   return strdup(strip_trail(pvd->publisher_id, ISO_MAX_PUBLISHER_ID));
 }
 
-/*!
+/**
    Return a string containing the PVD's system id with trailing
    blanks removed.
 */
@@ -1252,7 +1252,7 @@ iso9660_get_system_id(const iso9660_pvd_t *pvd)
   return strdup(strip_trail(pvd->system_id, ISO_MAX_SYSTEM_ID));
 }
 
-/*!
+/**
   Return the PVD's volume ID.
 */
 char *
@@ -1262,7 +1262,7 @@ iso9660_get_volume_id(const iso9660_pvd_t *pvd)
   return strdup(strip_trail(pvd->volume_id, ISO_MAX_VOLUME_ID));
 }
 
-/*!
+/**
   Return the PVD's volumeset ID.
   NULL is returned if there is some problem in getting this.
 */

--- a/lib/iso9660/iso9660_fs.c
+++ b/lib/iso9660/iso9660_fs.c
@@ -165,7 +165,7 @@ adjust_fuzzy_pvd( iso9660_t *p_iso )
 
 }
 
-/*!
+/**
   Open an ISO 9660 image for reading in either fuzzy mode or not.
 */
 static iso9660_t *
@@ -208,7 +208,7 @@ iso9660_open_ext_private (const char *psz_path,
   return NULL;
 }
 
-/*!
+/**
   Open an ISO 9660 image for reading. Maybe in the future we will have
   a mode. NULL is returned on error.
 
@@ -223,7 +223,7 @@ iso9660_open (const char *psz_path /*, mode*/)
   return iso9660_open_ext(psz_path, ISO_EXTENSION_NONE);
 }
 
-/*!
+/**
   Open an ISO 9660 image for reading allowing various ISO 9660
   extensions.  Maybe in the future we will have a mode. NULL is
   returned on error.
@@ -238,7 +238,7 @@ iso9660_open_ext (const char *psz_path,
 }
 
 
-/*! Open an ISO 9660 image for "fuzzy" reading. This means that we
+/** Open an ISO 9660 image for "fuzzy" reading. This means that we
   will try to guess various internal offset based on internal
   checks. This may be useful when trying to read an ISO 9660 image
   contained in a file format that libiso9660 doesn't know natively
@@ -258,7 +258,7 @@ iso9660_open_fuzzy (const char *psz_path, uint16_t i_fuzz /*, mode*/)
   return iso9660_open_fuzzy_ext(psz_path, ISO_EXTENSION_NONE, i_fuzz);
 }
 
-/*!
+/**
   Open an ISO 9660 image for reading with some tolerance for positioning
   of the ISO9660 image. We scan for ISO_STANDARD_ID and use that to set
   the eventual offset to adjust by (as long as that is <= i_fuzz).
@@ -276,7 +276,7 @@ iso9660_open_fuzzy_ext (const char *psz_path,
 				  true);
 }
 
-/*! Close previously opened ISO 9660 image and free resources
+/** Close previously opened ISO 9660 image and free resources
     associated with the image. Call this when done using using an ISO
     9660 image.
 
@@ -312,7 +312,7 @@ check_pvd (const iso9660_pvd_t *p_pvd, cdio_log_level_t log_level)
 }
 
 
-/*!
+/**
   Core procedure for the iso9660_ifs_get_###_id() calls.
   pvd_member/svd_member is a pointer to an achar_t or dchar_t
   ID string which we can superset as char.
@@ -377,7 +377,7 @@ get_member_id(iso9660_t *p_iso, cdio_utf8_t **p_psz_member_id,
 }
 
 
-/*!
+/**
   Return the application ID.  NULL is returned in psz_app_id if there
   is some problem in getting this.
 */
@@ -391,7 +391,7 @@ iso9660_ifs_get_application_id(iso9660_t *p_iso,
                        ISO_MAX_APPLICATION_ID);
 }
 
-/*!
+/**
   Return the Joliet level recognized for p_iso.
 */
 uint8_t iso9660_ifs_get_joliet_level(iso9660_t *p_iso)
@@ -400,7 +400,7 @@ uint8_t iso9660_ifs_get_joliet_level(iso9660_t *p_iso)
   return p_iso->u_joliet_level;
 }
 
-/*!
+/**
    Return a string containing the preparer id with trailing
    blanks removed.
 */
@@ -414,7 +414,7 @@ iso9660_ifs_get_preparer_id(iso9660_t *p_iso,
                        ISO_MAX_PREPARER_ID);
 }
 
-/*!
+/**
    Return a string containing the PVD's publisher id with trailing
    blanks removed.
 */
@@ -427,7 +427,7 @@ bool iso9660_ifs_get_publisher_id(iso9660_t *p_iso,
                        ISO_MAX_PUBLISHER_ID);
 }
 
-/*!
+/**
    Return a string containing the PVD's system id with trailing
    blanks removed.
 */
@@ -440,7 +440,7 @@ bool iso9660_ifs_get_system_id(iso9660_t *p_iso,
                        ISO_MAX_SYSTEM_ID);
 }
 
-/*!
+/**
    Return a string containing the PVD's volume id with trailing
    blanks removed.
 */
@@ -453,7 +453,7 @@ bool iso9660_ifs_get_volume_id(iso9660_t *p_iso,
                        ISO_MAX_VOLUME_ID);
 }
 
-/*!
+/**
    Return a string containing the PVD's volumeset id with trailing
    blanks removed.
 */
@@ -467,7 +467,7 @@ bool iso9660_ifs_get_volumeset_id(iso9660_t *p_iso,
 }
 
 
-/*!
+/**
   Read the Primary Volume Descriptor for an ISO 9660 image.
   True is returned if read, and false if there was an error.
 */
@@ -483,7 +483,7 @@ iso9660_ifs_read_pvd_loglevel (const iso9660_t *p_iso,
   return check_pvd(p_pvd, log_level);
 }
 
-/*!
+/**
   Read the Primary Volume Descriptor for an ISO 9660 image.
   True is returned if read, and false if there was an error.
 */
@@ -494,7 +494,7 @@ iso9660_ifs_read_pvd (const iso9660_t *p_iso, /*out*/ iso9660_pvd_t *p_pvd)
 }
 
 
-/*!
+/**
   Read the Super block of an ISO 9660 image. This is the
   Primary Volume Descriptor (PVD) and perhaps a Supplemental Volume
   Descriptor if (Joliet) extensions are acceptable.
@@ -547,7 +547,7 @@ iso9660_ifs_read_superblock (iso9660_t *p_iso,
   return true;
 }
 
-/*!
+/**
   Read the Super block of an ISO 9660 image but determine framesize
   and datastart and a possible additional offset. Generally here we are
   not reading an ISO 9660 image but a CD-Image which contains an ISO 9660
@@ -615,7 +615,7 @@ iso9660_ifs_fuzzy_read_superblock (iso9660_t *p_iso,
 }
 
 
-/*!
+/**
   Read the Primary Volume Descriptor for of CD.
 */
 bool
@@ -643,7 +643,7 @@ iso9660_fs_read_pvd(const CdIo_t *p_cdio, /*out*/ iso9660_pvd_t *p_pvd)
 }
 
 
-/*!
+/**
   Read the Super block of an ISO 9660 image. This is the
   Primary Volume Descriptor (PVD) and perhaps a Supplemental Volume
   Descriptor if (Joliet) extensions are acceptable.
@@ -709,7 +709,7 @@ iso9660_fs_read_superblock (CdIo_t *p_cdio,
   return true;
 }
 
-/*!
+/**
   Seek to a position and then read n blocks. Size read is returned.
 */
 static long int
@@ -729,7 +729,7 @@ iso9660_seek_read_framesize (const iso9660_t *p_iso, void *ptr,
   return cdio_stream_read (p_iso->stream, ptr, i_framesize, size);
 }
 
-/*!
+/**
   Seek to a position and then read n blocks. Size read is returned.
 */
 long int
@@ -741,7 +741,7 @@ iso9660_iso_seek_read (const iso9660_t *p_iso, void *ptr, lsn_t start,
 
 
 
-/*!
+/**
   Check for the end of a directory record list in a single directory
   block.  If at the end, set the offset to start of the next block and
   return "true". The caller often skips actions only when at the end
@@ -794,7 +794,7 @@ _iso9660_is_rock_ridge_enabled(void* p_image)
   return true;
 }
 
-/*!
+/**
   Convert a directory record name to a 0-terminated string.
   One of parameters alloc_result and cpy_result should be non-NULL to take
   the result.
@@ -1026,7 +1026,7 @@ fail:
   return NULL;
 }
 
-/*!
+/**
   Return the directory name stored in the iso9660_dir_t
 
   A string is allocated: the caller must deallocate. This routine
@@ -1338,7 +1338,7 @@ _fs_iso_stat_traverse (iso9660_t *p_iso, const iso9660_stat_t *_root,
   return NULL;
 }
 
-/*!
+/**
   Return file status for psz_path. NULL is returned on error.
 
   @param p_cdio the CD object to read from
@@ -1382,7 +1382,7 @@ typedef iso9660_stat_t * (stat_root_t) (void *p_image);
 typedef iso9660_stat_t * (stat_traverse_t)
   (const void *p_image, const iso9660_stat_t *_root, char **splitpath);
 
-/*!
+/**
   Get file status for psz_path into stat. NULL is returned on error.
   pathname version numbers in the ISO 9660
   name are dropped, i.e. ;1 is removed and if level 1 ISO-9660 names
@@ -1411,7 +1411,7 @@ fs_stat_translate (void *p_image, stat_root_t stat_root,
   return p_stat;
 }
 
-/*!
+/**
   Return file status for path name psz_path. NULL is returned on error.
   pathname version numbers in the ISO 9660 name are dropped, i.e. ;1
   is removed and if level 1 ISO-9660 names are downcased.
@@ -1432,7 +1432,7 @@ iso9660_fs_stat_translate (CdIo_t *p_cdio, const char psz_path[])
 			   psz_path);
 }
 
-/*!
+/**
   @param p_iso the ISO-9660 file image to get data from
 
   @param psz_path filename path translate
@@ -1451,7 +1451,7 @@ iso9660_ifs_stat_translate (iso9660_t *p_iso, const char psz_path[])
 }
 
 
-/*!
+/**
 
   @param p_cdio the CD object to read from
 
@@ -1481,7 +1481,7 @@ iso9660_ifs_stat (iso9660_t *p_iso, const char psz_path[])
   return stat;
 }
 
-/*!
+/**
   Read psz_path (a directory) and return a list of iso9660_stat_t
   pointers for the files inside that directory.
 
@@ -1591,7 +1591,7 @@ iso9660_fs_readdir (CdIo_t *p_cdio, const char psz_path[])
   return retval;
 }
 
-/*!
+/**
   Read psz_path (a directory) and return a list of iso9660_stat_t
   of the files inside that. The caller must free the returned result.
 */
@@ -1795,7 +1795,7 @@ find_lsn_recurse (void *p_image, iso9660_readdir_t iso9660_readdir,
   return NULL;
 }
 
-/*!
+/**
    Given a directory pointer, find the filesystem entry that contains
    lsn and return information about it.
 
@@ -1819,7 +1819,7 @@ iso9660_find_fs_lsn(CdIo_t *p_cdio, lsn_t i_lsn) __attribute__ ((alias ("iso9660
 iso9660_find_fs_lsn(CdIo_t *p_cdio, lsn_t i_lsn);
 #endif
 
-/*!
+/**
    Given a directory pointer, find the filesystem entry that contains
    LSN and return information about it.
 
@@ -1841,7 +1841,7 @@ iso9660_fs_find_lsn_with_path(CdIo_t *p_cdio, lsn_t i_lsn,
 			   "/", i_lsn, ppsz_full_filename);
 }
 
-/*!
+/**
    Given a directory pointer, find the filesystem entry that contains
    lsn and return information about it.
 
@@ -1913,7 +1913,7 @@ _iso9660_dd_find_lsn(void* p_image, lsn_t i_lsn)
 }
 #endif /* HAVE ROCK */
 
-/*!
+/**
    Given a directory pointer, find the filesystem entry that contains
    lsn and return information about it.
 
@@ -1937,7 +1937,7 @@ iso9660_ifs_find_lsn_with_path(iso9660_t *p_iso, lsn_t i_lsn,
 			   "/", i_lsn, ppsz_full_filename);
 }
 
-/*!
+/**
   Free the passed iso9660_stat_t structure.
 
   @param p_stat iso9660 stat buffer to free.
@@ -1954,7 +1954,7 @@ iso9660_stat_free(iso9660_stat_t *p_stat)
   }
 }
 
-/*!
+/**
   Free the passed CdioISOC9660FileList_t structure.
 */
 void
@@ -1962,7 +1962,7 @@ iso9660_filelist_free(CdioISO9660FileList_t *p_filelist) {
   _cdio_list_free(p_filelist, true, (CdioDataFree_t) iso9660_stat_free);
 }
 
-/*!
+/**
   Free the passed CdioISOC9660DirList_t structure.
 */
 void
@@ -1971,7 +1971,7 @@ iso9660_dirlist_free(CdioISO9660DirList_t *p_filelist) {
 }
 
 
-/*!
+/**
   Return true if ISO 9660 image has extended attributes (XA).
 */
 bool
@@ -2052,7 +2052,7 @@ iso_have_rr_traverse (iso9660_t *p_iso, const iso9660_stat_t *_root,
   return nope;
 }
 
-/*!
+/**
   Return "yup" if any file has Rock-Ridge extensions. Warning: this can
   be time consuming. On an ISO 9600 image with lots of files but no Rock-Ridge
   extensions, the entire directory structure will be scanned up to u_file_limit.

--- a/lib/iso9660/rock.c
+++ b/lib/iso9660/rock.c
@@ -160,7 +160,7 @@ is_rr_dd_enabled(void * p_image) {
   return !(p_header->u_flags & CDIO_HEADER_FLAGS_DISABLE_RR_DD);
 }
 
-/*!
+/**
   Get
   @return length of name field; 0: not found, -1: to be ignored
 */
@@ -419,7 +419,7 @@ _getbuf (void)
   return _buf[_i];
 }
 
-/*!
+/**
   Returns a string which interpreting the POSIX mode st_mode.
   For example:
   \verbatim
@@ -500,7 +500,7 @@ iso9660_get_rock_attr_str(posix_mode_t st_mode)
   return result;
 }
 
-/*!
+/**
   Returns POSIX mode bitstring for a given file.
 */
 mode_t

--- a/lib/iso9660/xa.c
+++ b/lib/iso9660/xa.c
@@ -30,7 +30,7 @@
 #include <sys/stat.h>
 #endif
 
-/*! String inside frame which identifies XA attributes.  Note should
+/** String inside frame which identifies XA attributes.  Note should
     come *before* public headers which does a #define of
     this name.
 */
@@ -61,7 +61,7 @@ _getbuf (void)
 {
   static char _buf[BUF_COUNT][BUF_SIZE];
   static int _num = -1;
-  
+
   _num++;
   _num %= BUF_COUNT;
 
@@ -70,8 +70,8 @@ _getbuf (void)
   return _buf[_num];
 }
 
-/*!
-  Returns a string which interpreting the extended attribute xa_attr. 
+/**
+  Returns a string which interpreting the extended attribute xa_attr.
   For example:
   \verbatim
   d---1xrxrxr
@@ -89,14 +89,14 @@ _getbuf (void)
    is you will either see "2-" or "-1" in the 4th & 5th positions.
 
   The 6th and 7th characters refer to permissions for a user while the
-  the 8th and 9th characters refer to permissions for a group while, and 
-  the 10th and 11th characters refer to permissions for a others. 
- 
-  In each of these pairs the first character (6, 8, 10) is "x" if the 
+  the 8th and 9th characters refer to permissions for a group while, and
+  the 10th and 11th characters refer to permissions for a others.
+
+  In each of these pairs the first character (6, 8, 10) is "x" if the
   entry is executable. For a directory this means the directory is
   allowed to be listed or "searched".
   The second character of a pair (7, 9, 11) is "r" if the entry is allowed
-  to be read. 
+  to be read.
 */
 
 const char *
@@ -127,11 +127,11 @@ iso9660_get_xa_attr_str (uint16_t xa_attr)
 }
 
 iso9660_xa_t *
-iso9660_xa_init (iso9660_xa_t *_xa, uint16_t uid, uint16_t gid, uint16_t attr, 
+iso9660_xa_init (iso9660_xa_t *_xa, uint16_t uid, uint16_t gid, uint16_t attr,
 	      uint8_t filenum)
 {
   cdio_assert (_xa != NULL);
-  
+
   _xa->user_id = uint16_to_be (uid);
   _xa->group_id = uint16_to_be (gid);
   _xa->attributes = uint16_to_be (attr);
@@ -141,10 +141,10 @@ iso9660_xa_init (iso9660_xa_t *_xa, uint16_t uid, uint16_t gid, uint16_t attr,
 
   _xa->filenum = filenum;
 
-  _xa->reserved[0] 
-    = _xa->reserved[1] 
-    = _xa->reserved[2] 
-    = _xa->reserved[3] 
+  _xa->reserved[0]
+    = _xa->reserved[1]
+    = _xa->reserved[2]
+    = _xa->reserved[3]
     = _xa->reserved[4] = 0x00;
 
   return _xa;
@@ -157,33 +157,32 @@ iso9660_xa_free (iso9660_xa_t *_xa)
     free(_xa);
 }
 
-/*!
+/**
   Returns POSIX mode bitstring for a given file.
 */
-posix_mode_t 
-iso9660_get_posix_filemode_from_xa(uint16_t i_perms) 
+posix_mode_t
+iso9660_get_posix_filemode_from_xa(uint16_t i_perms)
 {
   posix_mode_t mode = 0;
-  
+
   if (i_perms & XA_PERM_RUSR)  mode |= S_IRUSR;
   if (i_perms & XA_PERM_XUSR)  mode |= S_IXUSR;
-  
+
 #ifdef S_IRGRP
   if (i_perms & XA_PERM_RGRP)  mode |= S_IRGRP;
 #endif
 #ifdef S_IXGRP
   if (i_perms & XA_PERM_XGRP)  mode |= S_IXGRP;
 #endif
-  
+
 #ifdef S_IROTH
   if (i_perms & XA_PERM_ROTH)  mode |= S_IROTH;
 #endif
 #ifdef S_IXOTH
   if (i_perms & XA_PERM_XOTH)  mode |= S_IXOTH;
 #endif
-  
+
   if (i_perms & XA_ATTR_DIRECTORY)  mode |= S_IFDIR;
-  
+
   return mode;
 }
-

--- a/lib/udf/filemode.c
+++ b/lib/udf/filemode.c
@@ -145,7 +145,7 @@ ftypelet (mode_t bits)
   return '?';
 }
 
-/*! udf_mode_string - fill in string STR with an ls-style ASCII
+/** udf_mode_string - fill in string STR with an ls-style ASCII
    representation of the st_mode field of file stats block STATP.
    10 characters are stored in STR; no terminating null is added.
    The characters stored in STR are:

--- a/lib/udf/udf.c
+++ b/lib/udf/udf.c
@@ -42,13 +42,13 @@ icbtag_flag_enum_t       debug_flag_enum;
 ecma_167_enum1_t         debug_ecma_167_enum1;
 ecma_167_timezone_enum_t debug_ecma_167_timezone_enum;
 udf_enum1_t              debug_udf_enum1;
-  
 
-/*!
+
+/**
   Returns POSIX mode bitstring for a given file.
 */
-mode_t 
-udf_get_posix_filemode(const udf_dirent_t *p_udf_dirent) 
+mode_t
+udf_get_posix_filemode(const udf_dirent_t *p_udf_dirent)
 {
   udf_file_entry_t udf_fe;
   mode_t mode = 0;
@@ -65,13 +65,13 @@ udf_get_posix_filemode(const udf_dirent_t *p_udf_dirent)
     if (i_perms & FE_PERM_U_READ)  mode |= S_IRUSR;
     if (i_perms & FE_PERM_U_WRITE) mode |= S_IWUSR;
     if (i_perms & FE_PERM_U_EXEC)  mode |= S_IXUSR;
-    
+
 #ifdef S_IRGRP
     if (i_perms & FE_PERM_G_READ)  mode |= S_IRGRP;
     if (i_perms & FE_PERM_G_WRITE) mode |= S_IWGRP;
     if (i_perms & FE_PERM_G_EXEC)  mode |= S_IXGRP;
 #endif
-    
+
 #ifdef S_IROTH
     if (i_perms & FE_PERM_O_READ)  mode |= S_IROTH;
     if (i_perms & FE_PERM_O_WRITE) mode |= S_IWOTH;
@@ -79,7 +79,7 @@ udf_get_posix_filemode(const udf_dirent_t *p_udf_dirent)
 #endif
 
     switch (udf_fe.icb_tag.file_type) {
-    case ICBTAG_FILE_TYPE_DIRECTORY: 
+    case ICBTAG_FILE_TYPE_DIRECTORY:
       mode |= S_IFDIR;
       break;
     case ICBTAG_FILE_TYPE_REGULAR:
@@ -103,20 +103,20 @@ udf_get_posix_filemode(const udf_dirent_t *p_udf_dirent)
       break;
     default: ;
     };
-  
+
 #ifdef S_ISUID
     if (i_flags & ICBTAG_FLAG_SETUID) mode |= S_ISUID;
     if (i_flags & ICBTAG_FLAG_SETGID) mode |= S_ISGID;
     if (i_flags & ICBTAG_FLAG_STICKY) mode |= S_ISVTX;
 #endif
   }
-  
+
   return mode;
-  
+
 }
 
-/*!
-  Return the partition number of the the opened udf handle. -1 
+/**
+  Return the partition number of the the opened udf handle. -1
   Is returned if we have an error.
 */
 int16_t udf_get_part_number(const udf_t *p_udf)
@@ -124,4 +124,3 @@ int16_t udf_get_part_number(const udf_t *p_udf)
   if (!p_udf) return -1;
   return p_udf->i_partition;
 }
-

--- a/lib/udf/udf_file.c
+++ b/lib/udf/udf_file.c
@@ -56,7 +56,7 @@ udf_get_file_entry(const udf_dirent_t *p_udf_dirent,
   return true;
 }
 
-/*!
+/**
   Return the file id descriptor of the given file.
 */
 bool udf_get_fileid_descriptor(const udf_dirent_t *p_udf_dirent,
@@ -73,7 +73,7 @@ bool udf_get_fileid_descriptor(const udf_dirent_t *p_udf_dirent,
 }
 
 
-/*!
+/**
   Return the number of hard links of the file. Return 0 if error.
 */
 uint16_t udf_get_link_count(const udf_dirent_t *p_udf_dirent)
@@ -84,7 +84,7 @@ uint16_t udf_get_link_count(const udf_dirent_t *p_udf_dirent)
   return 0; /* Error. Non-error case handled above. */
 }
 
-/*!
+/**
   Return the file length the file. Return 2147483647L if error.
 */
 uint64_t udf_get_file_length(const udf_dirent_t *p_udf_dirent)
@@ -95,7 +95,7 @@ uint64_t udf_get_file_length(const udf_dirent_t *p_udf_dirent)
   return 2147483647L; /* Error. Non-error case handled above. */
 }
 
-/*!
+/**
   Return true if the file is a directory.
 */
 bool

--- a/lib/udf/udf_fs.c
+++ b/lib/udf/udf_fs.c
@@ -332,7 +332,7 @@ udf_new_dirent(udf_file_entry_t *p_udf_fe, udf_t *p_udf,
   return p_udf_dirent;
 }
 
-/*!
+/**
   Seek to a position i_start and then read i_blocks. Number of blocks read is
   returned. One normally expects the return to be equal to i_blocks.
 */
@@ -366,7 +366,7 @@ udf_read_sectors (const udf_t *p_udf, void *ptr, lsn_t i_start,
   }
 }
 
-/*!
+/**
   Open an UDF for reading. Maybe in the future we will have
   a mode. NULL is returned on error.
 
@@ -555,7 +555,7 @@ udf_get_logical_volume_id(udf_t *p_udf, /*out*/ char *psz_logvolid, unsigned int
   return logvolid_len;
 }
 
-/*!
+/**
   Get the root in p_udf. If b_any_partition is false then
   the root must be in the given partition.
   NULL is returned if the partition is not found or a root is not found or
@@ -645,7 +645,7 @@ udf_get_root (udf_t *p_udf, bool b_any_partition, partition_num_t i_partition)
   CDIO_FREE_IF_NOT_NULL(x); \
   x=NULL
 
-/*!
+/**
   Close UDF and free resources associated with p_udf.
 */
 bool
@@ -837,7 +837,7 @@ udf_readdir(udf_dirent_t *p_udf_dirent)
   return NULL;
 }
 
-/*!
+/**
   free free resources associated with p_udf_dirent.
 */
 bool

--- a/lib/udf/udf_time.c
+++ b/lib/udf/udf_time.c
@@ -1,4 +1,4 @@
-/* 
+/*
   Copyright (C) 2005, 2008, 2011 Rocky Bernstein <rocky@gnu.org>
   Copyright (C) 1993, 1994, 1995, 1996, 1997 Free Software Foundation, Inc.
 
@@ -25,7 +25,7 @@
 
        10/04/98: added new table-based lookup after seeing how ugly the
                  gnu code is
-  
+
    blf 09/27/99: ripped out all the old code and inserted new table from
                  John Brockmeyer (without leap second corrections)
                  rewrote udf_stamp_to_time and fixed timezone
@@ -63,7 +63,7 @@ enum {
   SECS_PER_HOUR	   = (60 * SECS_PER_MINUTE),
   SECS_PER_DAY	   = SECS_PER_HOUR * HOURS_PER_DAY
 } debug_udf_time_enum;
-  
+
 #ifndef __isleap
 /* Nonzero if YEAR is a leap year (every 4 years,
    except every 100th isn't, and every 400th is).  */
@@ -83,23 +83,23 @@ static const unsigned short int __mon_yday[2][13] =
 #define SPY(y,l,s) (SECS_PER_DAY * (DAYS_PER_YEAR*y+l)+s) /* Seconds per year */
 
 static time_t year_seconds[MAX_YEAR_SECONDS]= {
-  /*1970*/ SPY( 0, 0,0), SPY( 1, 0,0), SPY( 2, 0,0), SPY( 3, 1,0), 
-  /*1974*/ SPY( 4, 1,0), SPY( 5, 1,0), SPY( 6, 1,0), SPY( 7, 2,0), 
-  /*1978*/ SPY( 8, 2,0), SPY( 9, 2,0), SPY(10, 2,0), SPY(11, 3,0), 
-  /*1982*/ SPY(12, 3,0), SPY(13, 3,0), SPY(14, 3,0), SPY(15, 4,0), 
-  /*1986*/ SPY(16, 4,0), SPY(17, 4,0), SPY(18, 4,0), SPY(19, 5,0), 
-  /*1990*/ SPY(20, 5,0), SPY(21, 5,0), SPY(22, 5,0), SPY(23, 6,0), 
-  /*1994*/ SPY(24, 6,0), SPY(25, 6,0), SPY(26, 6,0), SPY(27, 7,0), 
-  /*1998*/ SPY(28, 7,0), SPY(29, 7,0), SPY(30, 7,0), SPY(31, 8,0), 
-  /*2002*/ SPY(32, 8,0), SPY(33, 8,0), SPY(34, 8,0), SPY(35, 9,0), 
-  /*2006*/ SPY(36, 9,0), SPY(37, 9,0), SPY(38, 9,0), SPY(39,10,0), 
-  /*2010*/ SPY(40,10,0), SPY(41,10,0), SPY(42,10,0), SPY(43,11,0), 
-  /*2014*/ SPY(44,11,0), SPY(45,11,0), SPY(46,11,0), SPY(47,12,0), 
-  /*2018*/ SPY(48,12,0), SPY(49,12,0), SPY(50,12,0), SPY(51,13,0), 
-  /*2022*/ SPY(52,13,0), SPY(53,13,0), SPY(54,13,0), SPY(55,14,0), 
-  /*2026*/ SPY(56,14,0), SPY(57,14,0), SPY(58,14,0), SPY(59,15,0), 
-  /*2030*/ SPY(60,15,0), SPY(61,15,0), SPY(62,15,0), SPY(63,16,0), 
-  /*2034*/ SPY(64,16,0), SPY(65,16,0), SPY(66,16,0), SPY(67,17,0), 
+  /*1970*/ SPY( 0, 0,0), SPY( 1, 0,0), SPY( 2, 0,0), SPY( 3, 1,0),
+  /*1974*/ SPY( 4, 1,0), SPY( 5, 1,0), SPY( 6, 1,0), SPY( 7, 2,0),
+  /*1978*/ SPY( 8, 2,0), SPY( 9, 2,0), SPY(10, 2,0), SPY(11, 3,0),
+  /*1982*/ SPY(12, 3,0), SPY(13, 3,0), SPY(14, 3,0), SPY(15, 4,0),
+  /*1986*/ SPY(16, 4,0), SPY(17, 4,0), SPY(18, 4,0), SPY(19, 5,0),
+  /*1990*/ SPY(20, 5,0), SPY(21, 5,0), SPY(22, 5,0), SPY(23, 6,0),
+  /*1994*/ SPY(24, 6,0), SPY(25, 6,0), SPY(26, 6,0), SPY(27, 7,0),
+  /*1998*/ SPY(28, 7,0), SPY(29, 7,0), SPY(30, 7,0), SPY(31, 8,0),
+  /*2002*/ SPY(32, 8,0), SPY(33, 8,0), SPY(34, 8,0), SPY(35, 9,0),
+  /*2006*/ SPY(36, 9,0), SPY(37, 9,0), SPY(38, 9,0), SPY(39,10,0),
+  /*2010*/ SPY(40,10,0), SPY(41,10,0), SPY(42,10,0), SPY(43,11,0),
+  /*2014*/ SPY(44,11,0), SPY(45,11,0), SPY(46,11,0), SPY(47,12,0),
+  /*2018*/ SPY(48,12,0), SPY(49,12,0), SPY(50,12,0), SPY(51,13,0),
+  /*2022*/ SPY(52,13,0), SPY(53,13,0), SPY(54,13,0), SPY(55,14,0),
+  /*2026*/ SPY(56,14,0), SPY(57,14,0), SPY(58,14,0), SPY(59,15,0),
+  /*2030*/ SPY(60,15,0), SPY(61,15,0), SPY(62,15,0), SPY(63,16,0),
+  /*2034*/ SPY(64,16,0), SPY(65,16,0), SPY(66,16,0), SPY(67,17,0),
   /*2038*/ SPY(68,17,0)
 };
 
@@ -108,13 +108,13 @@ extern long timezone;
 #endif
 
 time_t *
-udf_stamp_to_time(time_t *dest, long int *dest_usec, 
+udf_stamp_to_time(time_t *dest, long int *dest_usec,
 		  const udf_timestamp_t src)
 {
   int yday;
   uint8_t type = src.type_tz >> 12;
   int16_t offset;
-  
+
   if (type == 1) {
     offset = src.type_tz << 4;
     /* sign extent offset */
@@ -124,7 +124,7 @@ udf_stamp_to_time(time_t *dest, long int *dest_usec,
   }
   else
     offset = 0;
-  
+
   if ((src.year < EPOCH_YEAR) ||
       (src.year >= EPOCH_YEAR+MAX_YEAR_SECONDS))
     {
@@ -134,10 +134,10 @@ udf_stamp_to_time(time_t *dest, long int *dest_usec,
     }
   *dest = year_seconds[src.year - EPOCH_YEAR];
   *dest -= offset * SECS_PER_MINUTE;
-  
+
   yday = ((__mon_yday[__isleap (src.year)]
 	   [src.month-1]) + (src.day-1));
-  *dest += src.second + 
+  *dest += src.second +
     ( SECS_PER_MINUTE *
       ( ( (yday* HOURS_PER_DAY) + src.hour ) * 60 + src.minute ) );
 
@@ -148,7 +148,7 @@ udf_stamp_to_time(time_t *dest, long int *dest_usec,
 }
 
 #ifdef HAVE_STRUCT_TIMESPEC
-/*!
+/**
   Convert a UDF timestamp to a time_t. If microseconds are desired,
   use dest_usec. The return value is the same as dest. */
 udf_timestamp_t *
@@ -159,15 +159,15 @@ udf_timespec_to_stamp(const struct timespec ts, udf_timestamp_t *dest)
   int16_t offset = 0;
   int16_t tv_sec;
 
-#ifdef HAVE_TIMEZONE_VAR  
+#ifdef HAVE_TIMEZONE_VAR
   offset = -timezone;
 #endif
-  
+
   if (!dest)
     return dest;
-  
+
   dest->type_tz = 0x1000 | (offset & 0x0FFF);
-  
+
   tv_sec       = ts.tv_sec + (offset * SECS_PER_MINUTE);
   days         = tv_sec / SECS_PER_DAY;
   rem          = tv_sec % SECS_PER_DAY;
@@ -176,13 +176,13 @@ udf_timespec_to_stamp(const struct timespec ts, udf_timestamp_t *dest)
   dest->minute = rem / SECS_PER_MINUTE;
   dest->second = rem % SECS_PER_MINUTE;
   y            = EPOCH_YEAR;
-  
+
 #define DIV(a,b) ((a) / (b) - ((a) % (b) < 0))
 #define LEAPS_THRU_END_OF(y) (DIV (y, 4) - DIV (y, 100) + DIV (y, 400))
-  
+
   while (days < 0 || days >= (__isleap(y) ? DAYS_PER_YEAR+1 : DAYS_PER_YEAR)) {
     long int yg = y + days / DAYS_PER_YEAR - (days % DAYS_PER_YEAR < 0);
-    
+
     /* Adjust DAYS and Y to match the guessed year.  */
     days -= ((yg - y) * DAYS_PER_YEAR
 	     + LEAPS_THRU_END_OF (yg - 1)
@@ -196,18 +196,18 @@ udf_timespec_to_stamp(const struct timespec ts, udf_timestamp_t *dest)
   days -= ip[y];
   dest->month = y + 1;
   dest->day   = days + 1;
-  
+
   dest->centiseconds = ts.tv_nsec / 10000000;
   dest->hundreds_of_microseconds = ( (ts.tv_nsec / 1000)
 				     - (dest->centiseconds * 10000) ) / 100;
-  dest->microseconds = ( (ts.tv_nsec / 1000) 
+  dest->microseconds = ( (ts.tv_nsec / 1000)
 			 - (dest->centiseconds * 10000)
 			 - (dest->hundreds_of_microseconds * 100) );
   return dest;
 }
 #endif
 
-/*!
+/**
   Return the modification time of the file.
  */
 time_t
@@ -222,7 +222,7 @@ udf_get_modification_time(const udf_dirent_t *p_udf_dirent)
   return 0;
 }
 
-/*!
+/**
   Return the access time of the file.
  */
 time_t
@@ -237,7 +237,7 @@ udf_get_access_time(const udf_dirent_t *p_udf_dirent)
   return 0;
 }
 
-/*!
+/**
   Return the attribute (most recent create or access) time of the file
  */
 time_t
@@ -251,4 +251,3 @@ udf_get_attribute_time(const udf_dirent_t *p_udf_dirent)
   }
   return 0;
 }
-

--- a/src/cd-drive.c
+++ b/src/cd-drive.c
@@ -188,7 +188,7 @@ _log_handler (cdio_log_level_t level, const char message[])
   gl_default_cdio_log_handler (level, message);
 }
 
-/*! Prints out SCSI-MMC drive features  */
+/** Prints out SCSI-MMC drive features  */
 static void
 print_mmc_drive_level(CdIo_t *p_cdio)
 {

--- a/src/cddb.c
+++ b/src/cddb.c
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2005, 2008, 2009, 2011 Rocky Bernstein <rocky@gnu.org>
-  
+
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
@@ -26,14 +26,14 @@
 
 cddb_opts_t cddb_opts;
 
-/*!
+/**
    Returns the sum of the decimal digits in a number. Eg. 1955 = 20
 */
 static int
 cddb_dec_digit_sum(int n)
 {
   int ret=0;
-  
+
   for (;;) {
     ret += n%10;
     n    = n/10;
@@ -41,11 +41,11 @@ cddb_dec_digit_sum(int n)
   }
 }
 
-/*!
+/**
    Compute the CDDB disk ID for an Audio disk.  This is a funny checksum
    consisting of the concatenation of 3 things:
-      the sum of the decimal digits of sizes of all tracks, 
-      the total length of the disk, and 
+      the sum of the decimal digits of sizes of all tracks,
+      the total length of the disk, and
       the number of tracks.
 */
 uint32_t
@@ -54,7 +54,7 @@ cddb_discid(CdIo_t *p_cdio, track_t i_tracks)
   int i,t,n=0;
   msf_t start_msf;
   msf_t msf;
-  
+
   for (i = 1; i <= i_tracks; i++) {
     cdio_get_track_msf(p_cdio, i, &msf);
     n += cddb_dec_digit_sum(cdio_audio_get_msf_seconds(&msf));
@@ -62,54 +62,54 @@ cddb_discid(CdIo_t *p_cdio, track_t i_tracks)
 
   cdio_get_track_msf(p_cdio, 1, &start_msf);
   cdio_get_track_msf(p_cdio, CDIO_CDROM_LEADOUT_TRACK, &msf);
-  
+
   t = cdio_audio_get_msf_seconds(&msf)-cdio_audio_get_msf_seconds(&start_msf);
-  
+
   return ((n % 0xff) << 24 | t << 8 | i_tracks);
 }
 
 #ifdef HAVE_CDDB
-bool 
-init_cddb(CdIo_t *p_cdio, cddb_conn_t **pp_conn, cddb_disc_t **pp_cddb_disc, 
+bool
+init_cddb(CdIo_t *p_cdio, cddb_conn_t **pp_conn, cddb_disc_t **pp_cddb_disc,
 	  error_fn_t errmsg, track_t i_first_track, track_t i_tracks,
 	  int *i_cddb_matches)
 {
   track_t i;
-  
+
   *pp_conn =  cddb_new();
   *pp_cddb_disc = NULL;
-  
+
   if (!*pp_conn) {
     errmsg("unable to initialize libcddb");
     return false;
   }
-  
-  if (NULL == cddb_opts.email) 
+
+  if (NULL == cddb_opts.email)
     cddb_set_email_address(*pp_conn, "me@home");
-  else 
+  else
     cddb_set_email_address(*pp_conn, cddb_opts.email);
-  
-  if (NULL == cddb_opts.server) 
+
+  if (NULL == cddb_opts.server)
     cddb_set_server_name(*pp_conn, "gnudb.gnudb.org");
-  else 
+  else
     cddb_set_server_name(*pp_conn, cddb_opts.server);
-  
-  if (cddb_opts.timeout >= 0) 
+
+  if (cddb_opts.timeout >= 0)
     cddb_set_timeout(*pp_conn, cddb_opts.timeout);
-  
+
   cddb_set_server_port(*pp_conn, cddb_opts.port);
-  
-  if (cddb_opts.http) 
+
+  if (cddb_opts.http)
     cddb_http_enable(*pp_conn);
-  else 
+  else
     cddb_http_disable(*pp_conn);
-  
-  if (NULL != cddb_opts.cachedir) 
+
+  if (NULL != cddb_opts.cachedir)
     cddb_cache_set_dir(*pp_conn, cddb_opts.cachedir);
-  
-  if (cddb_opts.disable_cache) 
+
+  if (cddb_opts.disable_cache)
     cddb_cache_disable(*pp_conn);
-  
+
   *pp_cddb_disc = cddb_disc_new();
   if (!*pp_cddb_disc) {
     errmsg("unable to create CDDB disc structure");
@@ -117,25 +117,25 @@ init_cddb(CdIo_t *p_cdio, cddb_conn_t **pp_conn, cddb_disc_t **pp_cddb_disc,
     return false;
   }
   for(i = 0; i < i_tracks; i++) {
-    cddb_track_t *t = cddb_track_new(); 
-    cddb_track_set_frame_offset(t, 
+    cddb_track_t *t = cddb_track_new();
+    cddb_track_set_frame_offset(t,
 				cdio_get_track_lba(p_cdio, i+i_first_track));
     cddb_disc_add_track(*pp_cddb_disc, t);
   }
-  
-  cddb_disc_set_length(*pp_cddb_disc, 
-		       cdio_get_track_lba(p_cdio, CDIO_CDROM_LEADOUT_TRACK) 
+
+  cddb_disc_set_length(*pp_cddb_disc,
+		       cdio_get_track_lba(p_cdio, CDIO_CDROM_LEADOUT_TRACK)
 		       / CDIO_CD_FRAMES_PER_SEC);
-  
+
   if (!cddb_disc_calc_discid(*pp_cddb_disc)) {
     errmsg("libcddb calc discid failed.");
     cddb_destroy(*pp_conn);
     return false;
   }
-  
+
   *i_cddb_matches = cddb_query(*pp_conn, *pp_cddb_disc);
-  
-  if (-1 == *i_cddb_matches) 
+
+  if (-1 == *i_cddb_matches)
     errmsg(cddb_error_str(cddb_errno(*pp_conn)));
 
   cddb_read(*pp_conn, *pp_cddb_disc);

--- a/src/cddb.h
+++ b/src/cddb.h
@@ -2,7 +2,7 @@
   $Id: cddb.h,v 1.6 2008/06/25 08:01:54 rocky Exp $
 
   Copyright (C) 2005, 2007, 2008, 2009 Rocky Bernstein <rocky@gnu.org>
-  
+
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-typedef struct cddb_opts_s 
+typedef struct cddb_opts_s
 {
   char          *email;  /* email to report to CDDB server. */
   char          *server; /* CDDB server to contact */
@@ -30,11 +30,11 @@ typedef struct cddb_opts_s
 
 extern cddb_opts_t cddb_opts;
 
-/*!
+/**
    Compute the CDDB disk ID for an Audio disk.  This is a funny checksum
    consisting of the concatenation of 3 things:
-      the sum of the decimal digits of sizes of all tracks, 
-      the total length of the disk, and 
+      the sum of the decimal digits of sizes of all tracks,
+      the total length of the disk, and
       the number of tracks.
 */
 uint32_t cddb_discid(CdIo_t *p_cdio, track_t i_tracks);
@@ -44,7 +44,7 @@ uint32_t cddb_discid(CdIo_t *p_cdio, track_t i_tracks);
 
 typedef void (*error_fn_t) (const char *msg);
 
-bool init_cddb(CdIo_t *p_cdio, cddb_conn_t **pp_conn, 
-	       cddb_disc_t **pp_cddb_disc, error_fn_t errmsg,  
+bool init_cddb(CdIo_t *p_cdio, cddb_conn_t **pp_conn,
+	       cddb_disc_t **pp_cddb_disc, error_fn_t errmsg,
 	       track_t i_first_track, track_t i_tracks, int *i_cddb_matches);
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -85,7 +85,7 @@ PARTICULAR PURPOSE.\n\
 
 }
 
-/*! Device input routine. If successful we return an open CdIo_t
+/** Device input routine. If successful we return an open CdIo_t
     pointer. On error the program exits.
  */
 CdIo_t *
@@ -185,7 +185,7 @@ fillout_device_name(const char *device_name)
 #endif
 }
 
-/*! Prints out SCSI-MMC drive features  */
+/** Prints out SCSI-MMC drive features  */
 void
 print_mmc_drive_features(CdIo_t *p_cdio)
 {
@@ -458,7 +458,7 @@ print_drive_capabilities(cdio_drive_read_cap_t  i_read_cap,
   }
 }
 
-/*! Common place for output routine. In some environments, like XBOX,
+/** Common place for output routine. In some environments, like XBOX,
   it may not be desirable to send output to stdout and stderr. */
 void
 report (FILE *stream, const char *psz_format,  ...)

--- a/src/util.h
+++ b/src/util.h
@@ -112,36 +112,36 @@ extern char *source_name;
 extern char *program_name;
 extern cdio_log_handler_t gl_default_cdio_log_handler;
 
-/*! Common error exit routine which frees p_cdio. rc is the
+/** Common error exit routine which frees p_cdio. rc is the
     return code to pass to exit.
 */
 void myexit(CdIo_t *p_cdio, int rc);
 
-/*! Print our version string */
+/** Print our version string */
 void print_version (char *psz_program, const char *psz_version,
 		    int no_header, bool version_only);
 
-/*! Device input routine. If successful we return an open CdIo_t
+/** Device input routine. If successful we return an open CdIo_t
     pointer. On error the program exits.
  */
 CdIo_t *
 open_input(const char *psz_source, source_image_t source_image,
 	   const char *psz_access_mode);
 
-/*! On Unixish OS's we fill out the device name, from a short name.
+/** On Unixish OS's we fill out the device name, from a short name.
     For example cdrom might become /dev/cdrom.
 */
 char *fillout_device_name(const char *device_name);
 
-/*! Prints out SCSI-MMC drive features  */
+/** Prints out SCSI-MMC drive features  */
 void  print_mmc_drive_features(CdIo *p_cdio);
 
-/*! Prints out drive capabilities */
+/** Prints out drive capabilities */
 void print_drive_capabilities(cdio_drive_read_cap_t  p_read_cap,
 			      cdio_drive_write_cap_t p_write_cap,
 			      cdio_drive_misc_cap_t  p_misc_cap);
 
-/*! Common place for output routine. In some environments, like XBOX,
+/** Common place for output routine. In some environments, like XBOX,
   it may not be desirable to send output to stdout and stderr. */
 void report (FILE *stream, const char *psz_format, ...);
 


### PR DESCRIPTION
Change MMC5 references to MMC6 2g when possible.
Reformat using clang-format the changed headers.