### PR TITLE
iso9660: bound Rock Ridge extension parsing

### DIFF
--- a/lib/iso9660/iso9660_fs.c
+++ b/lib/iso9660/iso9660_fs.c
@@ -853,9 +853,16 @@ _iso9660_dir_to_statbuf (iso9660_dir_t *p_iso9660_dir,
   lsn_t extent_lsn;
   bool first_extent;
 
-  if (!dir_len) return NULL;
+  if (dir_len < sizeof(iso9660_dir_t)) return NULL;
 
   i_fname = from_711(p_iso9660_dir->filename.len);
+  {
+    unsigned int su_offset = sizeof(iso9660_dir_t) + i_fname;
+    if (su_offset & 1)
+      su_offset++;
+    if (su_offset > dir_len)
+      return NULL;
+  }
 
   /* .. string in statbuf is one longer than in p_iso9660_dir's listing '\1' */
   stat_len = sizeof(iso9660_stat_t) + i_fname + 2;
@@ -974,12 +981,6 @@ _iso9660_dir_to_statbuf (iso9660_dir_t *p_iso9660_dir,
   }
 
   iso9660_get_dtime(&(p_iso9660_dir->recording_time), true, &(p_stat->tm));
-
-  if (dir_len < sizeof(iso9660_dir_t)) {
-    iso9660_stat_free(p_stat);
-    return NULL;
-  }
-
 
   {
     int su_length = iso9660_get_dir_len(p_iso9660_dir)

--- a/lib/iso9660/rock.c
+++ b/lib/iso9660/rock.c
@@ -139,11 +139,15 @@ realloc_symlink(/*in/out*/ iso9660_stat_t *p_stat, uint8_t i_grow)
     p_stat->rr.TIME_FIELD.b_longdate =				\
       (0 != (rr->u.TF.flags & ISO_ROCK_TF_LONG_FORM));		\
     if (p_stat->rr.TIME_FIELD.b_longdate) {			\
+      if ((size_t) cnt + sizeof(iso9660_ltime_t) > rr->len - 5) \
+        goto out;						\
       memcpy(&(p_stat->rr.TIME_FIELD.t.ltime),			\
 	     &(rr->u.TF.time_bytes[cnt]),			\
 	     sizeof(iso9660_ltime_t));				\
       cnt += sizeof(iso9660_ltime_t);				\
     } else {							\
+      if ((size_t) cnt + sizeof(iso9660_dtime_t) > rr->len - 5) \
+        goto out;						\
       memcpy(&(p_stat->rr.TIME_FIELD.t.dtime),			\
 	     &(rr->u.TF.time_bytes[cnt]),			\
 	     sizeof(iso9660_dtime_t));				\
@@ -190,6 +194,8 @@ repeat:
 
     while (len > 1){ /* There may be one byte for padding somewhere */
       rr = (iso_extension_record_t *) chr;
+      if (len < 4 || rr->len < 4 || rr->len > len)
+        goto out;
       sig = *chr+(*(chr+1) << 8);
 
       /* We used to check for some valid values of SIG, specifically
@@ -205,6 +211,8 @@ repeat:
 
       switch(sig) {
       case SIG('S','P'):
+	if (rr->len < 4 + sizeof(rr->u.SP))
+	  goto out;
 	CHECK_SP({cdio_warn("Invalid Rock Ridge SP field"); goto out;});
 	p_stat->rr.u_su_fields |= ISO_ROCK_SUF_SP;
 	break;
@@ -216,6 +224,8 @@ repeat:
 	  if ('\1' == p_iso9660_dir->filename.str[1] && 1 == i_fname)
 	    break;
 	}
+	if (rr->len < 4 + sizeof(rr->u.CE))
+	  goto out;
 	CHECK_CE({cdio_warn("Invalid Rock Ridge CE field"); goto out;});
 	p_stat->rr.u_su_fields |= ISO_ROCK_SUF_CE;
 	/* Though no mastering utility in its right mind would produce anything
@@ -224,6 +234,8 @@ repeat:
 	*/
 	break;
       case SIG('E','R'):
+	if (rr->len < 8 || rr->u.ER.len_id > rr->len - 8)
+	  goto out;
 	cdio_debug("ISO 9660 Extensions: ");
 	{
 	  int p;
@@ -233,6 +245,8 @@ repeat:
 	break;
       case SIG('N','M'):
 	/* Alternate name */
+	if (rr->len < 5)
+	  goto out;
 	p_stat->rr.u_su_fields |= ISO_ROCK_SUF_NM;
 	if (truncate)
 	  break;
@@ -259,6 +273,8 @@ repeat:
 	break;
       case SIG('P','X'):
 	/* POSIX file attributes */
+	if (rr->len < 4 + sizeof(rr->u.PX))
+	  goto out;
 	p_stat->rr.st_mode   = from_733(rr->u.PX.st_mode);
 	p_stat->rr.st_nlinks = from_733(rr->u.PX.st_nlinks);
 	p_stat->rr.st_uid    = from_733(rr->u.PX.st_uid);
@@ -271,30 +287,38 @@ repeat:
 	  uint8_t slen;
 	  iso_rock_sl_part_t * p_sl;
 	  iso_rock_sl_part_t * p_oldsl;
+	  if (rr->len < 5)
+	    goto out;
 	  slen = rr->len - 5;
 	  p_sl = &rr->u.SL.link;
 	  p_stat->rr.i_symlink = symlink_len;
 	  p_stat->rr.u_su_fields |= ISO_ROCK_SUF_SL;
 	  while (slen > 1){
 	    rootflag = 0;
+	    if (p_sl->len > slen - 2)
+	      goto out;
 	    switch(p_sl->flags &~1){
 	    case 0:
-	      realloc_symlink(p_stat, p_sl->len);
+	      if (!realloc_symlink(p_stat, p_sl->len))
+		goto out;
 	      memcpy(&(p_stat->rr.psz_symlink[p_stat->rr.i_symlink]),
 		     p_sl->text, p_sl->len);
 	      p_stat->rr.i_symlink += p_sl->len;
 	      break;
 	    case 4:
-	      realloc_symlink(p_stat, 1);
+	      if (!realloc_symlink(p_stat, 1))
+		goto out;
 	      p_stat->rr.psz_symlink[p_stat->rr.i_symlink++] = '.';
 	      /* continue into next case. */
 	    case 2:
-	      realloc_symlink(p_stat, 1);
+	      if (!realloc_symlink(p_stat, 1))
+		goto out;
 	      p_stat->rr.psz_symlink[p_stat->rr.i_symlink++] = '.';
 	      break;
 	    case 8:
 	      rootflag = 1;
-	      realloc_symlink(p_stat, 1);
+	      if (!realloc_symlink(p_stat, 1))
+		goto out;
 	      p_stat->rr.psz_symlink[p_stat->rr.i_symlink++] = '/';
 	      break;
 	    default:
@@ -314,19 +338,23 @@ repeat:
 	     * If this component record isn't continued, then append a '/'.
 	     */
 	    if (!rootflag && (p_oldsl->flags & 1) == 0) {
-	      realloc_symlink(p_stat, 1);
+	      if (!realloc_symlink(p_stat, 1))
+		goto out;
 	      p_stat->rr.psz_symlink[p_stat->rr.i_symlink++] = '/';
 	    }
 	  }
 	}
 	symlink_len = p_stat->rr.i_symlink;
-	realloc_symlink(p_stat, 1);
+	if (!realloc_symlink(p_stat, 1))
+	  goto out;
 	p_stat->rr.psz_symlink[symlink_len]='\0';
 	break;
       case SIG('T','F'):
 	/* Time stamp(s) for a file */
 	{
 	  int cnt = 0;
+	  if (rr->len < 5)
+	    goto out;
 	  add_time(ISO_ROCK_TF_CREATE,     create);
 	  add_time(ISO_ROCK_TF_MODIFY,     modify);
 	  add_time(ISO_ROCK_TF_ACCESS,     access);
@@ -339,6 +367,8 @@ repeat:
 	}
       case SIG('C','L'):
 	/* Child Link for a deep directory */
+	if (rr->len < 4 + sizeof(rr->u.CL))
+	  goto out;
 	if (!is_rr_dd_enabled(p_image))
 	  break;
 	{


### PR DESCRIPTION
Malformed Rock Ridge system-use entries can make
get_rock_ridge_filename() read beyond the containing ISO directory
record during directory enumeration, crashing applications that inspect
untrusted images.

Validate directory-record layout before parsing Rock Ridge data, then
ensure every extension header and payload fits within the remaining
system-use area. Check symlink buffer allocation before writing to it.