### PR TITLE
cdrdao: reject directives before tracks

### DIFF
--- a/lib/driver/image/cdrdao.c
+++ b/lib/driver/image/cdrdao.c
@@ -646,6 +646,8 @@ parse_tocfile (_img_private_t *cd, const char *psz_cue_name)
 	/* track flags */
 	/* [NO] COPY | [NO] PRE_EMPHASIS */
       } else if (0 == strcmp ("NO", psz_keyword)) {
+	if (i_track < 0)
+	  goto not_in_global_section;
 	if (NULL != (psz_field = strtok_r(NULL, " \t\n\r", &saveptr))) {
 	  if (0 == strcmp ("COPY", psz_field)) {
 	    if (NULL != cd)
@@ -678,6 +680,8 @@ parse_tocfile (_img_private_t *cd, const char *psz_cue_name)
 
 	/* ISRC "CCOOOYYSSSSS" */
       } else if (0 == strcmp ("ISRC", psz_keyword)) {
+	if (i_track < 0)
+	  goto not_in_global_section;
 	if (NULL != (psz_field = strtok_r(NULL, "\"\t\n\r", &saveptr))) {
 	  if (NULL != cd)
 	    cd->tocent[i_track].isrc = strdup(psz_field);
@@ -687,6 +691,8 @@ parse_tocfile (_img_private_t *cd, const char *psz_cue_name)
 
 	/* SILENCE <length> */
       } else if (0 == strcmp ("SILENCE", psz_keyword)) {
+	if (i_track < 0)
+	  goto not_in_global_section;
         if (NULL != (psz_field = strtok_r(NULL, " \t\n\r", &saveptr))) {
 	      if (NULL != cd)
 		  cd->tocent[i_track].silence = cdio_mmssff_to_lba (psz_field);

--- a/lib/driver/mmc/mmc.c
+++ b/lib/driver/mmc/mmc.c
@@ -1104,7 +1104,8 @@ mmc_last_cmd_sense(const CdIo_t *p_cdio, cdio_mmc_request_sense_t **pp_sense)
     if (!p_cdio) return DRIVER_OP_UNINIT;
     gen = p_cdio->env;
     *pp_sense = NULL;
-    if (gen->scsi_mmc_sense_valid <= 0)
+    if (gen->scsi_mmc_sense_valid <= 0
+	|| (size_t) gen->scsi_mmc_sense_valid > sizeof(gen->scsi_mmc_sense))
 	return 0;
     *pp_sense = calloc(1, gen->scsi_mmc_sense_valid);
     if (*pp_sense == NULL)

--- a/test/data/Makefile.am
+++ b/test/data/Makefile.am
@@ -17,6 +17,7 @@ check_DATA = \
 	bad-msf-3.toc  \
 	bad-tracknum-exceeded.cue \
 	bad-tracknum-exceeded.toc \
+	bad-pretrack-isrc.toc \
 	cdda.bin       \
 	cdda.cue       \
 	cdda_4_5.bin   \

--- a/test/data/bad-pretrack-isrc.toc
+++ b/test/data/bad-pretrack-isrc.toc
@@ -1,0 +1,3 @@
+// ISRC applies to a track and must not precede TRACK.
+CD_DA
+ISRC "AAAAAAAAAAAA"

--- a/test/driver/cdrdao.c
+++ b/test/driver/cdrdao.c
@@ -49,7 +49,7 @@
 #endif
 
 #define NUM_GOOD_TOCS 17
-#define NUM_BAD_TOCS 9
+#define NUM_BAD_TOCS 10
 int
 main(int argc, const char *argv[])
 {
@@ -82,7 +82,8 @@ main(int argc, const char *argv[])
     "bad-cat3.toc",
     "bad-file.toc",
     "bad-mode1.toc",
-    "bad-tracknum-exceeded.toc"
+    "bad-tracknum-exceeded.toc",
+    "bad-pretrack-isrc.toc"
   };
   int ret=0;
   unsigned int i;


### PR DESCRIPTION
CDRDAO TOCs may contain track-specific ISRC, SILENCE, or NO directives before
the first TRACK. parse_tocfile() used i_track -1 and overwrote state immediately
before tocent. With a global ISRC, this corrupts scsi_mmc_sense_valid; a later
mmc_last_cmd_sense() call copies past the image object and crashes.

Reject track directives outside tracks and validate the recorded sense length
before copying it. Valid per-track metadata remains accepted.