### PR TITLE
iso9660: bound Rock Ridge continuation areas

### DIFF
--- a/lib/iso9660/rock.c
+++ b/lib/iso9660/rock.c
@@ -113,6 +113,7 @@ realloc_symlink(/*in/out*/ iso9660_stat_t *p_stat, uint8_t i_grow)
     if (cont_offset >= ISO_BLOCKSIZE) FAIL;	\
     cont_size = from_733(rr->u.CE.size);	\
     if (cont_size >= ISO_BLOCKSIZE) FAIL;	\
+    if (cont_size > ISO_BLOCKSIZE - cont_offset) FAIL;\
   }
 
 #define SETUP_ROCK_RIDGE(DE, CHR, LEN)				\

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -25,7 +25,7 @@ SUBDIRS = data driver
 
 hack = check_sizeof testassert testgetdevices testischar \
        testisocd testisocd2 testisocd_joliet testiso9660 \
-       testisorr test_lib_driver_util testudf \
+       testisorr testisorr_ce test_lib_driver_util testudf \
        testpregap
 
 DATA_DIR       = @abs_top_srcdir@/test/data
@@ -42,6 +42,9 @@ testisocd_LDADD       = $(LIBISO9660_LIBS) $(LIBCDIO_LIBS) $(LTLIBICONV)
 testisocd2_LDADD      = $(LIBISO9660_LIBS) $(LIBCDIO_LIBS) $(LTLIBICONV)
 testisocd_joliet_LDADD= $(LIBISO9660_LIBS) $(LIBCDIO_LIBS) $(LTLIBICONV)
 testisorr_LDADD       = $(LIBISO9660_LIBS) $(LIBCDIO_LIBS) $(LTLIBICONV)
+testisorr_ce_SOURCES  = testisorr_ce.c $(top_srcdir)/lib/iso9660/rock.c
+testisorr_ce_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/lib/driver
+testisorr_ce_LDADD    = $(LIBCDIO_LIBS) $(LTLIBICONV)
 
 testudf_LDADD         = $(LIBUDF_LIBS) $(LIBCDIO_LIBS) $(LTLIBICONV)
 

--- a/test/testisorr_ce.c
+++ b/test/testisorr_ce.c
@@ -1,0 +1,87 @@
+/* Check that a Rock Ridge CE continuation cannot exceed its block. */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <cdio/iso9660.h>
+#include <cdio/rock.h>
+
+iso9660_stat_t *_iso9660_dd_find_lsn(void *image, lsn_t lsn);
+
+iso9660_stat_t *
+_iso9660_dd_find_lsn(void *image, lsn_t lsn)
+{
+  (void) image;
+  (void) lsn;
+  return NULL;
+}
+
+long int
+iso9660_iso_seek_read(const iso9660_t *image, void *buffer, lsn_t start,
+                      long int blocks)
+{
+  (void) image;
+  (void) start;
+  memset(buffer, 0, (size_t) blocks * ISO_BLOCKSIZE);
+  return ISO_BLOCKSIZE;
+}
+
+void
+iso9660_stat_free(iso9660_stat_t *p_stat)
+{
+  free(p_stat);
+}
+
+static void
+put_733(uint8_t *field, uint32_t value)
+{
+  field[0] = value;
+  field[1] = value >> 8;
+  field[2] = value >> 16;
+  field[3] = value >> 24;
+  field[4] = value >> 24;
+  field[5] = value >> 16;
+  field[6] = value >> 8;
+  field[7] = value;
+}
+
+int
+main(void)
+{
+  uint8_t *record = calloc(1, 62);
+  iso9660_stat_t *stat = calloc(1, sizeof(*stat) + 2);
+  char name[256] = "";
+  int ret = 1;
+
+  if (!record || !stat)
+    goto out;
+
+  record[0] = 62;
+  record[32] = 1;
+  record[33] = 'A';
+  record[34] = 'C';
+  record[35] = 'E';
+  record[36] = 28;
+  record[37] = 1;
+  put_733(&record[46], ISO_BLOCKSIZE - 1);
+  put_733(&record[54], ISO_BLOCKSIZE - 1);
+  stat->rr.b3_rock = dunno;
+
+  if (get_rock_ridge_filename((iso9660_dir_t *) record, record, name,
+                              stat) != 0)
+    goto out;
+  if (stat->rr.u_su_fields & ISO_ROCK_SUF_CE)
+    goto out;
+
+  ret = 0;
+out:
+  free(stat);
+  free(record);
+  return ret;
+}


### PR DESCRIPTION
Malformed Rock Ridge CE records could specify an offset and length that each fit within a sector but whose combined range extends past the one-sector continuation buffer. When get_rock_ridge_filename() processes an untrusted ISO directory entry, it could then read past that buffer and crash the application.

Validate the combined CE range before processing the continuation. The regression test covers a continuation beginning at the final byte of a block with an oversized length.