### PR TITLE
bincue: reserve a track entry for leadout

### DIFF
--- a/lib/driver/image/bincue.c
+++ b/lib/driver/image/bincue.c
@@ -491,6 +491,12 @@ parse_cuefile (_img_private_t *cd, const char *psz_cue_name)
           track_info_t  *this_track=NULL;
 
           if (cd) {
+            if (cd->gen.i_tracks >= CDIO_CD_MAX_TRACKS) {
+              cdio_log(log_level,
+                       "Too many tracks; maximum track number is %d.",
+                       CDIO_CD_MAX_TRACKS);
+              goto err_exit;
+            }
             this_track = &(cd->tocent[cd->gen.i_tracks]);
             this_track->track_num   = cd->gen.i_tracks;
             this_track->num_indices = 0;
@@ -498,12 +504,6 @@ parse_cuefile (_img_private_t *cd, const char *psz_cue_name)
             cd->gen.i_tracks++;
           }
           i++;
-	  if (i > CDIO_CD_MAX_TRACKS) {
-            cdio_warn(
-                "Track number %d is too large; maximum track number is %d.",
-                i, CDIO_CD_MAX_TRACKS);
-	    return DRIVER_OP_ERROR;
-	  }
 
 
           if (0 == strcmp("AUDIO", psz_field)) {

--- a/test/driver/bincue.c
+++ b/test/driver/bincue.c
@@ -78,7 +78,10 @@ check_too_many_tracks(void)
     cdio_destroy(p_cdio);
     return 1;
   }
+  return 0;
+}
 
+static int
 check_file_before_first_track(void)
 {
   CdIo_t *p_cdio = cdio_open_bincue(DATA_DIR "/cdda.cue");

--- a/test/driver/bincue.c
+++ b/test/driver/bincue.c
@@ -50,6 +50,38 @@
 
 #define NUM_GOOD_CUES 3
 #define NUM_BAD_CUES 8
+
+static int
+check_too_many_tracks(void)
+{
+  const char *cue_name = "bincue-too-many-tracks.cue";
+  FILE *cue;
+  CdIo_t *p_cdio;
+  unsigned int i;
+
+  cue = fopen(cue_name, "w");
+  if (!cue) {
+    printf("Can't create %s\n", cue_name);
+    return 1;
+  }
+
+  fprintf(cue, "FILE \"%s/cdda.bin\" BINARY\n", DATA_DIR);
+  for (i = 1; i <= CDIO_CD_MAX_TRACKS; i++)
+    fprintf(cue, "TRACK %02u AUDIO\n", i);
+  fprintf(cue, "TRACK %02u AUDIO\n", CDIO_CD_MAX_TRACKS);
+  fclose(cue);
+
+  p_cdio = cdio_open_bincue(cue_name);
+  remove(cue_name);
+  if (p_cdio) {
+    printf("Incorrect: %s with too many tracks opened.\n", cue_name);
+    cdio_destroy(p_cdio);
+    return 1;
+  }
+
+  return 0;
+}
+
 int
 main(int argc, const char *argv[])
 {
@@ -76,6 +108,10 @@ main(int argc, const char *argv[])
 
   psz_cuefile[sizeof(psz_cuefile)-1] = '\0';
   cdio_loglevel_default = (argc > 1) ? CDIO_LOG_DEBUG : CDIO_LOG_WARN;
+
+  if (check_too_many_tracks())
+    ret = 1;
+
   for (i=0; i<NUM_GOOD_CUES; i++) {
     char *psz_binfile;
     snprintf(psz_cuefile, sizeof(psz_cuefile)-1,


### PR DESCRIPTION
A crafted CUE sheet can supply 100 TRACK directives while the BIN/CUE image state has 100 entries total, with its final entry reserved for leadout. parse_cuefile() permitted the 100th track, and _init_bincue() then wrote the leadout to tocent[100], past the table and into adjacent image-driver state.

Reject an additional track before it consumes the leadout slot, preventing memory corruption when an application opens an untrusted CUE image.