### PR TITLE
bincue: avoid indexing before the first track

### DIFF
--- a/lib/driver/image/bincue.c
+++ b/lib/driver/image/bincue.c
@@ -450,9 +450,10 @@ parse_cuefile (_img_private_t *cd, const char *psz_cue_name)
           char *dirname = cdio_dirname(psz_cue_name);
           char *filename = cdio_abspath(dirname, psz_field);
           if (cd) {
-	      cd->gen.source_name = strdup(filename);
-	      cd->tocent[i].filename = strdup(filename);
-	  }
+            cd->gen.source_name = strdup(filename);
+            if (i >= 0)
+              cd->tocent[i].filename = strdup(filename);
+          }
           free(filename);
           free(dirname);
         } else {

--- a/test/driver/bincue.c
+++ b/test/driver/bincue.c
@@ -50,6 +50,21 @@
 
 #define NUM_GOOD_CUES 3
 #define NUM_BAD_CUES 8
+
+static int
+check_file_before_first_track(void)
+{
+  CdIo_t *p_cdio = cdio_open_bincue(DATA_DIR "/cdda.cue");
+
+  if (!p_cdio) {
+    printf("Can't open cdda.cue with FILE before TRACK\n");
+    return 1;
+  }
+
+  cdio_destroy(p_cdio);
+  return 0;
+}
+
 int
 main(int argc, const char *argv[])
 {
@@ -76,6 +91,10 @@ main(int argc, const char *argv[])
 
   psz_cuefile[sizeof(psz_cuefile)-1] = '\0';
   cdio_loglevel_default = (argc > 1) ? CDIO_LOG_DEBUG : CDIO_LOG_WARN;
+
+  if (check_file_before_first_track())
+    ret = 1;
+
   for (i=0; i<NUM_GOOD_CUES; i++) {
     char *psz_binfile;
     snprintf(psz_cuefile, sizeof(psz_cuefile)-1,


### PR DESCRIPTION
CUE sheets normally place FILE before the first TRACK. In `parse_cuefile()`, that leaves the current-track index at -1, but the FILE handler used it to store a per-track filename. Keep recording the image source filename and only update a track entry once a track exists.

This removes the UBSan negative-index diagnostic when opening ordinary CUE images and avoids leaking the duplicate filename allocation.