### PR TITLE
iso9660: reject oversized directory buffers

### DIFF
--- a/lib/iso9660/iso9660_fs.c
+++ b/lib/iso9660/iso9660_fs.c
@@ -779,6 +779,23 @@ iso9660_check_dir_block_end(iso9660_dir_t *p_iso9660_dir, unsigned *offset)
   return false;
 }
 
+/*
+ * The directory reader stores the block count in uint32_t and calculates
+ * buffer sizes from it. Reject sizes which would need 2^32 bytes after
+ * rounding up to ISO blocks.
+ */
+static bool
+iso9660_directory_block_count(uint64_t size, uint32_t *blocks)
+{
+  if (size > UINT32_MAX - (ISO_BLOCKSIZE - 1)) {
+    cdio_warn("Directory size is too large");
+    return false;
+  }
+
+  *blocks = CDIO_EXTENT_BLOCKS(size);
+  return true;
+}
+
 static inline bool
 _iso9660_is_rock_ridge_enabled(void* p_image)
 {
@@ -1153,7 +1170,8 @@ _fs_stat_traverse (const CdIo_t *p_cdio, const iso9660_stat_t *_root,
     return NULL;
 
   cdio_assert (_root->type == _STAT_DIR);
-  blocks = CDIO_EXTENT_BLOCKS(_root->total_size);
+  if (!iso9660_directory_block_count(_root->total_size, &blocks))
+    return NULL;
 
   _dirbuf = calloc(1, blocks * ISO_BLOCKSIZE);
   if (!_dirbuf)
@@ -1264,7 +1282,8 @@ _fs_iso_stat_traverse (iso9660_t *p_iso, const iso9660_stat_t *_root,
 
   cdio_assert (_root->type == _STAT_DIR);
 
-  blocks = CDIO_EXTENT_BLOCKS(_root->total_size);
+  if (!iso9660_directory_block_count(_root->total_size, &blocks))
+    return NULL;
   _dirbuf = calloc(1, blocks * ISO_BLOCKSIZE);
   if (!_dirbuf)
     {
@@ -1520,25 +1539,12 @@ iso9660_fs_readdir (CdIo_t *p_cdio, const char psz_path[])
     return NULL;
   }
 
-  /* Check for overflow on 32-bit systems.
-     uint32_t has a limited maximum value, and if p_stat->total_size (the total
-     size of the directory) is very large, the calculation might exceed this limit.
-  */
-  if (p_stat->total_size > SIZE_MAX / ISO_BLOCKSIZE) {
-    cdio_warn("Total size is too large");
+  if (!iso9660_directory_block_count(p_stat->total_size, &blocks)) {
     iso9660_stat_free(p_stat);
     return NULL;
   }
 
-  blocks = CDIO_EXTENT_BLOCKS(p_stat->total_size);
   retval = _cdio_list_new ();
-
-  /* Check for potential integer overflow when calculating total blocks */
-  if (blocks > (SIZE_MAX / ISO_BLOCKSIZE)) {
-    cdio_warn("Total size is too large");
-    iso9660_stat_free(p_stat);
-    return NULL;
-  }
 
   _dirbuf = calloc(1, blocks * ISO_BLOCKSIZE);
   if (!_dirbuf)
@@ -1622,18 +1628,10 @@ iso9660_ifs_readdir (iso9660_t *p_iso, const char psz_path[])
     return NULL;
   }
 
-  /* Check for overflow on 32-bit systems.
-     uint32_t has a limited maximum value, and if p_stat->total_size (the total
-     size of the directory) is very large, the calculation might exceed this limit.
-  */
-
-  if (p_stat->total_size > SIZE_MAX / ISO_BLOCKSIZE) {
-    cdio_warn("Total size is too large");
+  if (!iso9660_directory_block_count(p_stat->total_size, &blocks)) {
     iso9660_stat_free(p_stat);
     return NULL;
   }
-
-  blocks = CDIO_EXTENT_BLOCKS(p_stat->total_size);
   dirbuf_len = blocks * ISO_BLOCKSIZE;
   retval = _cdio_list_new ();
 
@@ -1999,7 +1997,8 @@ iso_have_rr_traverse (iso9660_t *p_iso, const iso9660_stat_t *_root,
 
   cdio_assert (_root->type == _STAT_DIR);
 
-   blocks = CDIO_EXTENT_BLOCKS(_root->total_size);
+  if (!iso9660_directory_block_count(_root->total_size, &blocks))
+    return dunno;
   _dirbuf = calloc(1, blocks * ISO_BLOCKSIZE);
   if (!_dirbuf)
     {

--- a/test/testiso9660.c
+++ b/test/testiso9660.c
@@ -22,6 +22,7 @@
 #endif
 
 #include <ctype.h>
+#include <stddef.h>
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
@@ -32,6 +33,7 @@
 #include <stdio.h>
 #endif
 
+#include <cdio/cdio.h>
 #include <cdio/iso9660.h>
 #include <cdio/bytesex.h>
 
@@ -39,6 +41,93 @@
 #define ISO_XA_FILE_ENTRY_FOO "FOO.;1"
 #define ISO_XA_FILE_ENTRY_FOO_ATTR "----1xrxrx-"
 #define ISO_XA_FILE_ENTRY_FOO_MODE 0551
+
+static int
+test_oversized_directory_size(void)
+{
+  const char *image_name = "bad-directory-size.bin";
+  const char *cue_name = "bad-directory-size.cue";
+  const uint8_t oversized_size[8] =
+    { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+  FILE *source;
+  FILE *image;
+  FILE *cue;
+  uint8_t buffer[4096];
+  size_t nread;
+  long int root_size_offset;
+  CdIo_t *cdio;
+  CdioISO9660FileList_t *entries;
+  int result = 1;
+
+  source = fopen("./data/isofs-m1.bin", "rb");
+  image = fopen(image_name, "wb");
+  if (!source || !image) {
+    printf("Could not create crafted ISO image\n");
+    goto out;
+  }
+
+  while ((nread = fread(buffer, 1, sizeof(buffer), source)) != 0) {
+    if (fwrite(buffer, 1, nread, image) != nread) {
+      printf("Could not write crafted ISO image\n");
+      goto out;
+    }
+  }
+  if (ferror(source)) {
+    printf("Could not read ISO fixture\n");
+    goto out;
+  }
+  fclose(source);
+  source = NULL;
+
+  root_size_offset = ISO_PVD_SECTOR * CDIO_CD_FRAMESIZE_RAW
+    + CDIO_CD_SYNC_SIZE + CDIO_CD_HEADER_SIZE
+    + offsetof(iso9660_pvd_t, root_directory_record)
+    + offsetof(iso9660_dir_t, size);
+  if (fseek(image, root_size_offset, SEEK_SET) != 0
+      || fwrite(oversized_size, 1, sizeof(oversized_size), image)
+         != sizeof(oversized_size)) {
+    printf("Could not set crafted directory size\n");
+    goto out;
+  }
+  fclose(image);
+  image = NULL;
+
+  cue = fopen(cue_name, "w");
+  if (!cue) {
+    printf("Could not create crafted CUE image\n");
+    goto out;
+  }
+  fputs("TRACK 01 MODE1/2352\n"
+        "FILE \"bad-directory-size.bin\" BINARY\n"
+        "INDEX 01 00:00:00\n", cue);
+  fclose(cue);
+  cue = NULL;
+
+  cdio = cdio_open(cue_name, DRIVER_BINCUE);
+  if (!cdio) {
+    printf("Could not open crafted CUE image\n");
+    goto out;
+  }
+  entries = iso9660_fs_readdir(cdio, "/");
+  cdio_destroy(cdio);
+  if (entries) {
+    printf("Incorrectly listed crafted oversized directory\n");
+    iso9660_dirlist_free(entries);
+    goto out;
+  }
+
+  result = 0;
+out:
+  if (source)
+    fclose(source);
+  if (image)
+    fclose(image);
+  if (cue)
+    fclose(cue);
+  remove(image_name);
+  remove(cue_name);
+  return result;
+}
 
 
 static bool
@@ -454,6 +543,9 @@ main (int argc, const char *argv[])
     iso9660_filelist_free(entries);
     iso9660_close(iso);
   }
+
+  if (test_oversized_directory_size())
+    return 56;
 
   return 0;
 }


### PR DESCRIPTION
A crafted ISO image can set a directory size near `0xffffffff`. `iso9660_fs_readdir()` rounds that size to ISO blocks in a `uint32_t`; the rounding addition wraps to zero, so it allocates a zero-byte directory buffer and then reads directory sectors into it.

This can produce an attacker-controlled heap out-of-bounds write when an application lists directories from an untrusted ISO image. Its immediate impact is a crash, with potential for more serious heap corruption depending on the caller and allocator.

Validate directory sizes before rounding them to blocks, and use the same check in the direct readdir, ISO stream, traversal, and Rock Ridge paths.